### PR TITLE
Fixed numerical instability for 0 distances.

### DIFF
--- a/src/schnetpack/nn/neighbors.py
+++ b/src/schnetpack/nn/neighbors.py
@@ -2,7 +2,7 @@ import torch
 from torch import nn as nn
 
 
-def atom_distances(positions, neighbors, cell=None, cell_offsets=None, return_directions=False):
+def atom_distances(positions, neighbors, cell=None, cell_offsets=None, return_directions=False, neighbor_mask=None):
     """
     Use advanced torch indexing to compute differentiable distances
     of every central atom to its relevant neighbors. Indices of the
@@ -14,6 +14,8 @@ def atom_distances(positions, neighbors, cell=None, cell_offsets=None, return_di
         cell (torch.Tensor): cell for periodic systems (B x 3 x 3)
         cell_offsets (torch.Tensor): offset of atom in cell coordinates (B x N_at x N_nbh x 3)
         return_directions (bool): If true, also return direction cosines.
+        neighbor_mask (torch.Tensor, optional): Boolean mask for neighbor positions. Required for the stable
+                                                computation of forces in molecules with different sizes.
 
     Returns:
         torch.Tensor: Distances of every atom to its neighbors (B x N_at x N_nbh)
@@ -40,6 +42,14 @@ def atom_distances(positions, neighbors, cell=None, cell_offsets=None, return_di
     # Compute vector lengths
     distances = torch.norm(dist_vec, 2, 3)
 
+    if neighbor_mask is not None:
+        # Avoid problems with zero distances in forces (instability of square root derivative at 0)
+        # This way is neccessary, as gradients do not work with inplace operations, such as e.g.
+        # -> distances[mask==0] = 0.0
+        tmp_distances = torch.zeros_like(distances)
+        tmp_distances[neighbor_mask != 0] = distances[neighbor_mask != 0]
+        distances = tmp_distances
+
     if return_directions:
         direction = dist_vec / distances[:, :, :, None]
         return distances, direction
@@ -62,18 +72,21 @@ class AtomDistances(nn.Module):
         super(AtomDistances, self).__init__()
         self.return_directions = return_directions
 
-    def forward(self, positions, neighbors, cell=None, cell_offsets=None):
+    def forward(self, positions, neighbors, cell=None, cell_offsets=None, neighbor_mask=None):
         """
         Args:
             positions (torch.Tensor): Atomic positions, differentiable torch Variable (B x N_at x 3)
             neighbors (torch.Tensor): Indices of neighboring atoms (B x N_at x N_nbh)
             cell (torch.tensor): cell for periodic systems (B x 3 x 3)
             cell_offsets (torch.Tensor): offset of atom in cell coordinates (B x N_at x N_nbh x 3)
+            neighbor_mask (torch.Tensor, optional): Boolean mask for neighbor positions. Required for the stable
+                                                    computation of forces in molecules with different sizes.
 
         Returns:
             torch.Tensor: Distances of every atoms to its neighbors (B x N_at x N_nbh)
         """
-        return atom_distances(positions, neighbors, cell, cell_offsets, return_directions=self.return_directions)
+        return atom_distances(positions, neighbors, cell, cell_offsets, return_directions=self.return_directions,
+                              neighbor_mask=neighbor_mask)
 
 
 def triple_distances(positions, neighbors_j, neighbors_k):

--- a/src/schnetpack/representation/hdnn.py
+++ b/src/schnetpack/representation/hdnn.py
@@ -187,7 +187,7 @@ class SymmetryFunctions(nn.Module):
             # Get atom types of neighbors
             Z_ij = snn.neighbor_elements(Z_rad, neighbors)
             # Compute distances
-            distances = snn.atom_distances(positions, neighbors)
+            distances = snn.atom_distances(positions, neighbors, neighbor_mask=neighbor_mask)
             radial_sf = self.RDF(distances, elemental_weights=Z_ij, neighbor_mask=neighbor_mask)
         else:
             radial_sf = None

--- a/src/schnetpack/representation/schnet.py
+++ b/src/schnetpack/representation/schnet.py
@@ -188,7 +188,7 @@ class SchNet(nn.Module):
         x = self.embedding(atomic_numbers)
 
         # spatial features
-        r_ij = self.distances(positions, neighbors, cell, cell_offset)
+        r_ij = self.distances(positions, neighbors, cell, cell_offset, neighbor_mask=neighbor_mask)
         f_ij = self.distance_expansion(r_ij)
 
         # interactions


### PR DESCRIPTION
This should solve the force training issue (#5). Problem were the 0-padded distances for molecules of unequal size. When computing forces, this leads to a zero division due to the square root operation. Added the option to provide a neighbor mask to the distance computation to filter these cases. 