### PR TITLE
Call sublayers directly in SchNetInteraction

### DIFF
--- a/src/schnetpack/representation/schnet.py
+++ b/src/schnetpack/representation/schnet.py
@@ -49,8 +49,8 @@ class SchNetInteraction(nn.Module):
         Returns:
             torch.Tensor: SchNet representation.
         """
-        v = self.cfconv.forward(x, r_ij, neighbors, neighbor_mask, f_ij=f_ij)
-        v = self.dense.forward(v)
+        v = self.cfconv(x, r_ij, neighbors, neighbor_mask, f_ij=f_ij)
+        v = self.dense(v)
         return v
 
 
@@ -98,8 +98,8 @@ class SchNetCutoffInteraction(nn.Module):
         Returns:
             torch.Tensor: SchNet representation.
         """
-        v = self.cfconv.forward(x, r_ij, neighbors, neighbor_mask, f_ij)
-        v = self.dense.forward(v)
+        v = self.cfconv(x, r_ij, neighbors, neighbor_mask, f_ij)
+        v = self.dense(v)
         return v
 
 


### PR DESCRIPTION
In SchNetInteraction, the sublayers were not called directly, but through forward method.