### PR TITLE
Allow nested indices in metrics and merging of datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ If you are using SchNetPack in you research, please cite:
 
 K.T. Schütt, P. Kessel, M. Gastegger, K. Nicoli, A. Tkatchenko, K.-R. Müller.
 SchNetPack: A Deep Learning Toolbox For Atomistic Systems.
-[arXiv:1809.01072](https://arxiv.org/abs/1809.01072). (2017)
+J. Chem. Theory Comput.
+[10.1021/acs.jctc.8b00908](http://dx.doi.org/10.1021/acs.jctc.8b00908)
+[arXiv:1809.01072](https://arxiv.org/abs/1809.01072). (2018)
 
 
 ## References

--- a/src/schnetpack/atomistic.py
+++ b/src/schnetpack/atomistic.py
@@ -174,7 +174,6 @@ class Atomwise(OutputModule):
             yi = yi + y0
 
         y = self.atom_pool(yi, atom_mask)
-
         result = {"y": y}
 
         if self.return_contributions:
@@ -219,7 +218,7 @@ class Energy(Atomwise):
                                      n_neurons, activation,
                                      return_contributions, return_force,
                                      create_graph, mean, stddev,
-                                     atomref, 100, outnet)
+                                     atomref, max_z, outnet)
 
     def forward(self, inputs):
         r"""

--- a/src/schnetpack/metrics.py
+++ b/src/schnetpack/metrics.py
@@ -68,7 +68,12 @@ class ModelBias(Metric):
         if self.model_output is None:
             yp = result
         else:
-            yp = result[self.model_output]
+            if type(self.model_output) is list:
+                for idx in self.model_output:
+                    result = result[idx]
+            else:
+                result = result[self.model_output]
+            yp = result
 
         diff = self._get_diff(y, yp)
         self.l2loss += torch.sum(diff.view(-1)).detach().cpu().data.numpy()
@@ -236,7 +241,12 @@ class HeatmapMAE(MeanAbsoluteError):
         if self.model_output is None:
             yp = result
         else:
-            yp = result[self.model_output]
+            if type(self.model_output) is list:
+                for idx in self.model_output:
+                    result = result[idx]
+            else:
+                result = result[self.model_output]
+            yp = result
 
         diff = self._get_diff(y, yp)
         self.l1loss += torch.sum(torch.abs(diff), 0).detach().cpu().data.numpy()
@@ -341,7 +351,12 @@ class AngleMSE(MeanSquaredError):
         if self.model_output is None:
             yp = result
         else:
-            yp = result[self.model_output]
+            if type(self.model_output) is list:
+                for idx in self.model_output:
+                    result = result[idx]
+            else:
+                result = result[self.model_output]
+            yp = result
 
         y = y.view(-1, y.size(-1))
         yp = yp.view(-1, yp.size(-1))
@@ -381,7 +396,12 @@ class AngleMAE(MeanAbsoluteError):
         if self.model_output is None:
             yp = result
         else:
-            yp = result[self.model_output]
+            if type(self.model_output) is list:
+                for idx in self.model_output:
+                    result = result[idx]
+            else:
+                result = result[self.model_output]
+            yp = result
 
         y = y.view(-1, y.size(-1))
         yp = yp.view(-1, yp.size(-1))
@@ -421,7 +441,12 @@ class AngleRMSE(RootMeanSquaredError):
         if self.model_output is None:
             yp = result
         else:
-            yp = result[self.model_output]
+            if type(self.model_output) is list:
+                for idx in self.model_output:
+                    result = result[idx]
+            else:
+                result = result[self.model_output]
+            yp = result
 
         y = y.view(-1, y.size(-1))
         yp = yp.view(-1, yp.size(-1))

--- a/src/schnetpack/metrics.py
+++ b/src/schnetpack/metrics.py
@@ -117,7 +117,12 @@ class MeanSquaredError(Metric):
         if self.model_output is None:
             yp = result
         else:
-            yp = result[self.model_output]
+            if type(self.model_output) is list:
+                for idx in self.model_output:
+                    result = result[idx]
+            else:
+                result = result[self.model_output]
+            yp = result
 
         diff = self._get_diff(y, yp)
         self.l2loss += torch.sum(diff.view(-1) ** 2).detach().cpu().data.numpy()
@@ -186,9 +191,18 @@ class MeanAbsoluteError(Metric):
         if self.model_output is None:
             yp = result
         else:
-            yp = result[self.model_output]
+            if type(self.model_output) is list:
+                for idx in self.model_output:
+                    result = result[idx]
+                    # print(result.shape)
+            else:
+                result = result[self.model_output]
+            yp = result
 
+        # print(yp, yp.shape, y.shape)
         diff = self._get_diff(y, yp)
+        # print(diff)
+        # print()
         self.l1loss += torch.sum(torch.abs(diff).view(-1), 0).detach().cpu().data.numpy()
         if self.element_wise:
             self.n_entries += torch.sum(batch[Structure.atom_mask]) * y.shape[-1]


### PR DESCRIPTION
You can now give a list of nested indices to metrics, e.g., `model_output = ['property_1', 1, slice(1,10)]`.