### PR TITLE
Add schnetpack_omdb.py to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     scripts=['src/scripts/schnetpack_qm9.py', 'src/scripts/schnetpack_md17.py',
              'src/scripts/schnetpack_matproj.py', 'src/scripts/schnetpack_molecular_dynamics.py',
              'src/scripts/schnetpack_ani1.py', 'src/scripts/schnetpack_load.py',
-             'src/sacred_scripts/run_schnetpack.py'],
+             'src/sacred_scripts/run_schnetpack.py', 'src/scripts/schnetpack_omdb.py'],
     package_dir={'': 'src'},
     python_requires='>=3.6',
     install_requires=[


### PR DESCRIPTION
Right now `schnetpack_omdb.py` is not available after installing schnetpack. This aims to fix it.