### PR TITLE
Automation with Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: python
 
-python:
-  - "3.6"
-
 install:
   - pip install -r docs/sphinx-requirements.txt
-  - pip install pytest
-  - pip install pytest-cov
   - pip install coveralls
-  - pip install .
+  - pip install tox
+
+matrix:
+  include:
+    python: 3.6
+    env: TOXENV=py36
 
 script:
-  - pytest --cov=schnetpack
-  
+  - tox
+
 after_success:
   - coveralls

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "torch>=0.4.1",
         "numpy",
         "ase>=3.16",
+        "h5py",
         "tensorboardX",
         "tqdm",
         "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,9 @@ setup(
         "numpy",
         "ase>=3.16",
         "tensorboardX",
-        "h5py"
+        "h5py",
+        "tqdm",
+        "pyyaml",
     ],
     extras_require={
         'test': ['pytest', 'sacred'],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "numpy",
         "ase>=3.16",
         "tensorboardX",
-        "h5py",
         "tqdm",
         "pyyaml",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py36
+
+[testenv]
+deps =
+    pytest
+    pytest-cov
+    sacred
+commands =
+    pip install -e .
+    pytest --cov=schnetpack
+# prevent exit when error is encountered
+ignore_errors = true


### PR DESCRIPTION
This PR contains the bare minimum configuration of `tox` to run `pytest` with coverage in py36 environment. The next step can be adding other python versions and various linters and black for quality assurance.
