### PR TITLE
Fix typo in default parsing for OMDB dataset and fix for dbpath not defined

### DIFF
--- a/src/schnetpack/datasets/omdb.py
+++ b/src/schnetpack/datasets/omdb.py
@@ -53,15 +53,16 @@ class OrganicMaterialsDatabase(DownloadableAtomsData):
         self.cutoff = cutoff
 
         dbpath = self.path.replace(".tar.gz", ".db")
+        self.dbpath = dbpath
 
-        if not os.path.exists(self.path) and not os.path.exists(dbpath):
+        if not os.path.exists(path) and not os.path.exists(dbpath):
             raise FileNotFoundError(
                 "Download OMDB dataset (e.g. OMDB-GAP1.tar.gz) from https://omdb.diracmaterials.org/dataset/ and set datapath to this file"
             )
 
         environment_provider = AseEnvironmentProvider(cutoff)
 
-        if download and not os.path.exists(self.dbpath):
+        if download and not os.path.exists(dbpath):
             # Convert OMDB .tar.gz into a .db file
             self._convert()
 

--- a/src/schnetpack/utils/script_utils/parsing.py
+++ b/src/schnetpack/utils/script_utils/parsing.py
@@ -326,7 +326,7 @@ def get_data_parsers():
         "--property",
         type=str,
         help="Database property to be predicted" " (default: %(default)s)",
-        default=[OrganicMaterialsDatabase.BandGap],
+        default=OrganicMaterialsDatabase.BandGap,
         choices=[OrganicMaterialsDatabase.BandGap],
     )
     return (


### PR DESCRIPTION
Hi, two very minor bugs are in the new spk version for the OMDB dataset. This PR fixes those:

1. self.dbpath is necessary to create the .db file but was not defined
2. the default property was set to [X] instead of X (so an error about an array instead of property)

Now the training runs properly again with the usual command:
```
spk_run.py train schnet omdb OMDB-GAP1_v1.1.tar.gz modeldir --cuda --batch_size 32 --features 64 --interactions 3 --cutoff 5 --split 9000 1000
```