### PR TITLE
Electronic spatial extent

### DIFF
--- a/src/schnetpack/atomistic/output_modules.py
+++ b/src/schnetpack/atomistic/output_modules.py
@@ -515,7 +515,11 @@ def symmetric_product(tensor):
 
 class ElectronicSpatialExtent(Atomwise):
     """
-    Predicts latent partial charges and calculates dipole moment.
+    Predicts the electronic spatial extent using a formalism close to the dipole moment layer.
+    The electronic spatial extent is discretized as a sum of atomic latent contributions
+    weighted by the squared distance of the atom from the center of mass (SchNetPack default).
+
+    .. math:: ESE = \sum_i^N | R_{i0} |^2 q(R)
 
     Args:
         n_in (int): input dimension of representation
@@ -527,16 +531,11 @@ class ElectronicSpatialExtent(Atomwise):
         property (str): name of the output property (default: "y")
         contributions (str or None): Name of property contributions in return dict.
             No contributions returned if None. (default: None)
-        predict_magnitude (bool): if True, predict the magnitude of the dipole moment
-            instead of the vector (default: False)
         mean (torch.FloatTensor or None): mean of dipole (default: None)
         stddev (torch.FloatTensor or None): stddev of dipole (default: None)
 
     Returns:
-        dict: vector for the dipole moment
-
-        If predict_magnitude is True returns the magnitude of the dipole moment
-        instead of the vector.
+        dict: the electronic spatial extent
 
         If contributions is not None latent atomic charges are added to the output
         dictionary.
@@ -570,7 +569,7 @@ class ElectronicSpatialExtent(Atomwise):
 
     def forward(self, inputs):
         """
-        predicts dipole moment
+        Predicts the electronic spatial extent.
         """
         positions = inputs[Properties.R]
         atom_mask = inputs[Properties.atom_mask][:, :, None]

--- a/src/schnetpack/utils/script_utils/model.py
+++ b/src/schnetpack/utils/script_utils/model.py
@@ -77,6 +77,13 @@ def get_output_module(args, representation, mean, stddev, atomref, aggregation_m
                 stddev=stddev[args.property],
                 property=args.property,
             )
+        elif args.property == spk.datasets.QM9.r2:
+            return schnetpack.atomistic.output_modules.ElectronicSpatialExtent(
+                args.features,
+                mean=mean[args.property],
+                stddev=stddev[args.property],
+                property=args.property,
+            )
         else:
             return schnetpack.atomistic.output_modules.Atomwise(
                 args.features,


### PR DESCRIPTION
Added new output layer for electronic spatial extent.
Now automatically uses this layer when training a QM9 model on the property.