### PR TITLE
update neighbor_pairs_mask for angular functions

### DIFF
--- a/src/schnetpack/data/atoms.py
+++ b/src/schnetpack/data/atoms.py
@@ -474,9 +474,11 @@ class AtomsConverter:
         inputs[Properties.neighbor_mask] = mask.float()
 
         if self.collect_triples:
-            inputs[Properties.neighbor_pairs_mask] = torch.ones_like(
-                inputs[Properties.neighbor_pairs_j]
-            ).float()
+            mask_triples = torch.ones_like(
+                inputs[Properties.neighbor_pairs_j])
+            mask_triples[inputs[Properties.neighbor_pairs_j]<0] = 0
+            mask_triples[inputs[Properties.neighbor_pairs_k]<0] = 0
+            inputs[Properties.neighbor_pairs_mask] = mask_triples.float()
 
         # Add batch dimension and move to CPU/GPU
         for key, value in inputs.items():


### PR DESCRIPTION
the nbh_idx_j, nbh_idx_k (neighbor_pairs_j, neighbor_pairs_k) has -1 indices which aren't actually neighbors, so we need to mask those out. fixes a bug with angular functions.