### PR TITLE
Fixed parser for sGDML calculator

### DIFF
--- a/src/schnetpack/md/parsers/md_options.py
+++ b/src/schnetpack/md/parsers/md_options.py
@@ -215,7 +215,7 @@ class CalculatorInit(Initializer):
             None,
         ),
         "orca": (calculators.OrcaCalculator, "orca", None),
-        "sgdml": (calculators.OrcaCalculator, "sgdml", None),
+        "sgdml": (calculators.SGDMLCalculator, "sgdml", None),
     }
     required_inputs = {
         "schnet": OrderedDict(


### PR DESCRIPTION
Fixed problem with sGDML calculator parser, which was using the default template of the Orca calculator.