### PR TITLE
Remove pytest-console-scripts from install_requires

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 install:
   - pip install -r docs/sphinx-requirements.txt
-  - pip install -e . [test]
+  - pip install -e .[test]
   - pip install codecov
   - pip install tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 install:
   - pip install -r docs/sphinx-requirements.txt
-  - pip install -e .[test]
   - pip install codecov
   - pip install tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 install:
   - pip install -r docs/sphinx-requirements.txt
+  - pip install -e . [test]
   - pip install codecov
   - pip install tox
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         "tensorboardX",
         "tqdm",
         "pyyaml",
-        "pytest-console-scripts",
     ],
     extras_require={"test": ["pytest", "sacred", "pytest-console-scripts"]},
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     pytest
     pytest-cov
 commands =
-    pip install -e .
+    pip install -e .[test]
     pytest --cov-report term --cov=schnetpack
 # prevent exit when error is encountered
 ignore_errors = true


### PR DESCRIPTION
It is only required for the tests, therefore it is enough to list it in `extras_require`. 