### PR TITLE
Adjusted matproj database downloader for new pymatgen Structure

### DIFF
--- a/src/schnetpack/datasets/matproj.py
+++ b/src/schnetpack/datasets/matproj.py
@@ -98,7 +98,7 @@ class MaterialsProject(DownloadableAtomsData):
             )
         try:
             from pymatgen.ext.matproj import MPRester
-            from pymatgen.core import Properties
+            from pymatgen.core import Structure
             import pymatgen as pmg
         except:
             raise ImportError(
@@ -130,7 +130,7 @@ class MaterialsProject(DownloadableAtomsData):
 
                         for k, q in enumerate(query):
                             s = q["structure"]
-                            if type(s) is Properties:
+                            if type(s) is Structure:
                                 at = Atoms(
                                     numbers=s.atomic_numbers,
                                     positions=s.cart_coords,


### PR DESCRIPTION
Tried to download the Materials Project database, but got an error from pymatgen.
Apparently the structure of pymatgen.core has changed: Properties has now become Structure.