### PR TITLE
Fix shape of energy in ase calculator

### DIFF
--- a/src/schnetpack/interfaces/ase_interface.py
+++ b/src/schnetpack/interfaces/ase_interface.py
@@ -114,7 +114,7 @@ class SpkCalculator(Calculator):
                     "properties!".format(self.model_energy)
                 )
             energy = model_results[self.model_energy].cpu().data.numpy()
-            results[self.energy] = energy.reshape(-1) * self.energy_units
+            results[self.energy] = energy.item() * self.energy_units  # ase calculator should return scalar energy
 
         if self.model_forces is not None:
             if self.model_forces not in model_results.keys():


### PR DESCRIPTION
Hi,

I noticed that the SchnetPack `ase` `Calculator` returns an energy in the shape `[-123.123]`, rather than `-123.123`, which is what `ase` [seems to expect](https://gitlab.com/ase/ase/blob/master/ase/calculators/calculator.py#L742). This fixes that!

Cheers!