### PR TITLE
fix CSVHook log on Windows

### DIFF
--- a/src/schnetpack/train/hooks/logging.py
+++ b/src/schnetpack/train/hooks/logging.py
@@ -178,7 +178,7 @@ class CSVHook(LoggingHook):
                 if i < len(self.metrics) - 1:
                     log += ","
 
-            with open(self.log_path, "a") as f:
+            with open(self.log_path, "a", newline="") as f:
                 f.write(log + os.linesep)
 
 


### PR DESCRIPTION
CSVHook::on_validation_end() fixed for newlines on Windows.