### PR TITLE
ENH: Restore EarlyStoppingHook state from checkpoint.

### DIFF
--- a/src/schnetpack/train/hooks/scheduling.py
+++ b/src/schnetpack/train/hooks/scheduling.py
@@ -23,11 +23,12 @@ class EarlyStoppingHook(Hook):
 
     @property
     def state_dict(self):
-        return {"counter": self.counter}
+        return {"counter": self.counter, "best_loss": self.best_loss}
 
     @state_dict.setter
     def state_dict(self, state_dict):
         self.counter = state_dict["counter"]
+        self.best_loss = state_dict["best_loss"]
 
     def on_validation_end(self, trainer, val_loss):
         if val_loss > (1 - self.threshold_ratio) * self.best_loss:

--- a/src/schnetpack/train/trainer.py
+++ b/src/schnetpack/train/trainer.py
@@ -111,7 +111,7 @@ class Trainer:
         self.optimizer.load_state_dict(state_dict["optimizer"])
         self._load_model_state_dict(state_dict["model"])
 
-        for h, s in zip(self.hooks, self.state_dict["hooks"]):
+        for h, s in zip(self.hooks, state_dict["hooks"]):
             h.state_dict = s
 
     def store_checkpoint(self):


### PR DESCRIPTION
This should fix #239 by making two changes:
- Store the best loss in the hook's `state_dict`.
- Ensuring `Trainer` uses the actual hook `state_dict` for restore.

Note that the changes to `Trainer` might break some workflows that involve adding or removing hooks before restoring from a checkpoint: this will now fail if the `state_dict` that is restored doesn't match the new hook setup. There should probably be a check to see if the setups match... or a separate method to do a "less thorough" restore.