### PR TITLE
Incorrect conversion which results in value be saved as double instead of float

### DIFF
--- a/src/schnetpack/datasets/qm9.py
+++ b/src/schnetpack/datasets/qm9.py
@@ -223,7 +223,7 @@ class QM9(DownloadableAtomsData):
                 lines = f.readlines()
                 l = lines[1].split()[2:]
                 for pn, p in zip(self.available_properties, l):
-                    properties[pn] = np.array([float(p) * self.units[pn]])
+                    properties[pn] = np.array([float(p * self.units[pn]]),dtype=np.float32)
                 with open(tmp, "wt") as fout:
                     for line in lines:
                         fout.write(line.replace("*^", "e"))


### PR DESCRIPTION
the float(p) had no effect and everything was saved as double taking twice the memory because self.units is not a float