### PR TITLE
Add ability to reconstruct the materials dataset at a timestamp

### DIFF
--- a/src/schnetpack/data/atoms.py
+++ b/src/schnetpack/data/atoms.py
@@ -414,7 +414,8 @@ class AtomsData(Dataset):
         )
 
         # read old database
-        atoms_list, properties_list = spk.utils.read_deprecated_database(self.dbpath)
+        atoms_list, properties_list, key_value_pairs_list \
+            = spk.utils.read_deprecated_database(self.dbpath)
         metadata = self.get_metadata()
 
         # move old database
@@ -423,12 +424,12 @@ class AtomsData(Dataset):
         # write updated database
         self.set_metadata(metadata=metadata)
         with connect(self.dbpath) as conn:
-            for atoms, properties in tqdm(
-                zip(atoms_list, properties_list),
+            for atoms, properties, key_value_pairs in tqdm(
+                zip(atoms_list, properties_list, key_value_pairs_list),
                 "Updating new database",
                 total=len(atoms_list),
             ):
-                conn.write(atoms, data=properties)
+                conn.write(atoms, data=properties, key_value_pairs=key_value_pairs)
 
 
 def _convert_atoms(

--- a/src/schnetpack/datasets/matproj.py
+++ b/src/schnetpack/datasets/matproj.py
@@ -84,6 +84,29 @@ class MaterialsProject(DownloadableAtomsData):
             environment_provider=self.environment_provider,
         )
 
+    def at_timestamp(self, timestamp):
+        """
+        Returns a new dataset that only consists of items created before
+        the given timestamp.
+
+        Args:
+            timestamp (str): timestamp
+
+        Returns:
+            schnetpack.datasets.matproj.MaterialsProject: dataset with subset of
+                original data
+        """
+        with connect(self.dbpath) as conn:
+            rows = conn.select(columns=['id', 'key_value_pairs'])
+            idxs = []
+            timestamps = []
+            for row in rows:
+                idxs.append(row.id - 1)
+                timestamps.append(row.key_value_pairs["created_at"])
+        idxs = np.array(idxs)
+        timestamps = np.array(timestamps)
+        return self.create_subset(idxs[timestamps <= timestamp])
+
     def _download(self):
         """
         Downloads dataset provided it does not exist in self.path

--- a/src/schnetpack/datasets/matproj.py
+++ b/src/schnetpack/datasets/matproj.py
@@ -125,6 +125,7 @@ class MaterialsProject(DownloadableAtomsData):
                                 "band_gap",
                                 "material_id",
                                 "warnings",
+                                "created_at",
                             ],
                         )
 
@@ -148,6 +149,10 @@ class MaterialsProject(DownloadableAtomsData):
                                             "total_magnetization"
                                         ],
                                         MaterialsProject.BandGap: q["band_gap"],
+                                    },
+                                    key_value_pairs={
+                                        "material_id": q["material_id"],
+                                        "created_at": q["created_at"],
                                     },
                                 )
         self.set_metadata({})

--- a/src/schnetpack/utils/script_utils/data.py
+++ b/src/schnetpack/utils/script_utils/data.py
@@ -162,6 +162,8 @@ def get_dataset(args, environment_provider, logging=None):
             load_only=[args.property],
             environment_provider=environment_provider,
         )
+        if args.timestamp:
+            mp = mp.at_timestamp(args.timestamp)
         return mp
     elif args.dataset == "omdb":
         if logging:

--- a/src/schnetpack/utils/script_utils/parsing.py
+++ b/src/schnetpack/utils/script_utils/parsing.py
@@ -383,6 +383,11 @@ def get_data_parsers():
         help="API key for Materials Project (see https://materialsproject.org/open)",
         default=None,
     )
+    matproj_parser.add_argument(
+        "--timestamp",
+        help="Timestamp at which to reconstruct the dataset",
+        default="2017-12-04 14:20",
+    )
     md17_parser = argparse.ArgumentParser(add_help=False, parents=[data_parser])
     md17_parser.add_argument(
         "--property",

--- a/src/schnetpack/utils/spk_utils.py
+++ b/src/schnetpack/utils/spk_utils.py
@@ -167,6 +167,7 @@ def read_deprecated_database(db_path):
         db_size = conn.count()
     atoms = []
     properties = []
+    key_value_pairs = []
 
     for idx in tqdm(range(1, db_size + 1), "Reading deprecated database"):
         with connect(db_path) as conn:
@@ -197,8 +198,9 @@ def read_deprecated_database(db_path):
 
         atoms.append(at)
         properties.append(props)
+        key_value_pairs.append(row.key_value_pairs)
 
-    return atoms, properties
+    return atoms, properties, key_value_pairs
 
 
 def activate_stress_computation(model, stress="stress"):


### PR DESCRIPTION
- Stores the `created_at` property.
- adds `at_timestamp()` to `MaterialsProject`, which creates a subset of the dataset at a given timestamp. The dataset from the SchNet JCP paper (69640 structures) is recovered with `2017-12-04 14:20`.
- adds `--timestamp` to `spk_run.py train schnet matproj` with default set to `2017-12-04 14:20`.