### PR TITLE
Numeric datatypes in argparse key-value-pairs

### DIFF
--- a/src/schnetpack/utils/script_utils/parsing.py
+++ b/src/schnetpack/utils/script_utils/parsing.py
@@ -13,8 +13,9 @@ class StoreDictKeyPair(argparse.Action):
     From https://stackoverflow.com/a/42355279
     """
 
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+    def __init__(self, option_strings, dest, nargs=None, val_type=str, **kwargs):
         self._nargs = nargs
+        self.val_type = val_type
         super(StoreDictKeyPair, self).__init__(
             option_strings, dest, nargs=nargs, **kwargs
         )
@@ -23,6 +24,11 @@ class StoreDictKeyPair(argparse.Action):
         my_dict = {}
         for kv in values:
             k, v = kv.split("=")
+            # typecast
+            if self.val_type == int:
+                v = int(float(v))
+            else:
+                v = self.val_type(v)
             my_dict[k] = v
         setattr(namespace, self.dest, my_dict)
 
@@ -539,6 +545,7 @@ def get_data_parsers():
         metavar="KEY=VAL",
         help="Define loss tradeoff weights with prop=weight. (default: %(default)s)",
         default=dict(),
+        val_type=float,
     )
     return (
         data_parser,

--- a/src/scripts/spk_run.py
+++ b/src/scripts/spk_run.py
@@ -29,7 +29,7 @@ def main(args):
 
     # get dataset
     environment_provider = get_environment_provider(train_args, device=device)
-    dataset = get_dataset(args, environment_provider=environment_provider)
+    dataset = get_dataset(train_args, environment_provider=environment_provider)
 
     # get dataloaders
     split_path = os.path.join(args.modelpath, "split.npz")

--- a/src/scripts/spk_run.py
+++ b/src/scripts/spk_run.py
@@ -29,7 +29,7 @@ def main(args):
 
     # get dataset
     environment_provider = get_environment_provider(train_args, device=device)
-    dataset = get_dataset(train_args, environment_provider=environment_provider)
+    dataset = get_dataset(args, environment_provider=environment_provider)
 
     # get dataloaders
     split_path = os.path.join(args.modelpath, "split.npz")


### PR DESCRIPTION
The argparse key-value pairs did not allow float values, which are needed for e.g. the loss tradeoff