### PR TITLE
Specifying devices when loading system state in a MD simulation

### DIFF
--- a/src/schnetpack/md/parsers/md_setup.py
+++ b/src/schnetpack/md/parsers/md_setup.py
@@ -86,11 +86,11 @@ class MDSimulation:
 
         # If requested, read restart data
         if self.restart and (self.restart is not None):
-            state_dict = torch.load(self.restart)
+            state_dict = torch.load(self.restart, map_location=self.device)
             simulator.restart_simulation(state_dict, soft=False)
             logging.info(f"Restarting simulation from {self.restart}...")
         elif self.load_system_state:
-            state_dict = torch.load(self.load_system_state)
+            state_dict = torch.load(self.load_system_state, map_location=self.device)
             simulator.load_system_state(state_dict)
             logging.info(f"Loaded system state from {self.load_system_state}...")
 


### PR DESCRIPTION
Making sure all tensors are on the same device during a MD simulation.

This is useful when training and MD prediciton are performed at different devices.