### PR TITLE
fix small bug

### DIFF
--- a/src/schnetpack/model/pes.py
+++ b/src/schnetpack/model/pes.py
@@ -202,7 +202,7 @@ class PESModel(AtomisticModel):
         for metric_name, pmetric in self.metrics.items():
             prop, name = metric_name.split("_")
             self.log(
-                f"{subset}_{name}",
+                f"{subset}_{metric_name}",
                 pmetric(pred[prop], batch[self.targets[prop]]),
                 on_step=False,
                 on_epoch=True,


### PR DESCRIPTION
logging did not capture property metrics, because the property info was removed for the labels.
name: mse/mae/...
metrics_name: energy_mae/force_mae/...