### PR TITLE
Disable automatic use of torchscript in MD calculators

### DIFF
--- a/src/schnetpack/md/md_configs/calculator/spk.yaml
+++ b/src/schnetpack/md/md_configs/calculator/spk.yaml
@@ -8,7 +8,7 @@ energy_units: kcal / mol
 position_units: Angstrom
 energy_label: energy
 stress_label: null
-script_model: true
+script_model: false
 
 defaults:
   - neighbor_list: ase

--- a/src/schnetpack/md/md_configs/calculator/spk_ensemble.yaml
+++ b/src/schnetpack/md/md_configs/calculator/spk_ensemble.yaml
@@ -9,7 +9,7 @@ energy_units: kcal / mol
 position_units: Angstrom
 energy_label: energy
 stress_label: null
-script_model: true
+script_model: false
 
 defaults:
   - neighbor_list: ase


### PR DESCRIPTION
Conversion of loaded models in MD calculators to torschript now disabled by default