### PR TITLE
Fixed sign for shift type cutoff

### DIFF
--- a/src/schnetpack/atomistic/electrostatic.py
+++ b/src/schnetpack/atomistic/electrostatic.py
@@ -138,7 +138,7 @@ class EnergyCoulomb(nn.Module):
 
         # Apply cutoff if requested (shifting to zero)
         if self.cutoff is not None:
-            potential = potential - self.shift ** 2 / potential - 2.0 * self.shift
+            potential = potential + self.shift ** 2 / potential - 2.0 * self.shift
             potential = torch.where(
                 d_ij <= self.cutoff, potential, torch.zeros_like(potential)
             )


### PR DESCRIPTION
Fixed sign error in shift type cutoff for Coulomb potentials. Should be:

![image](https://user-images.githubusercontent.com/36198330/138318997-6aefd597-ab1e-48be-b100-6cdcc0a0d26e.png)

for f(r) and f'(r) to be 0 at r = r_cut