### PR TITLE
Fix AtomsDataSubset for use inside ConcatAtomsData

### DIFF
--- a/src/schnetpack/data/atoms.py
+++ b/src/schnetpack/data/atoms.py
@@ -605,7 +605,7 @@ class AtomsDataSubset(Subset):
         return self.dataset.get_atomref(properties)
 
     def get_properties(self, idx, load_only=None):
-        return self.dataset.get_properties(idx, load_only)
+        return self.dataset.get_properties(self.indices[idx], load_only)
 
     def set_load_only(self, load_only):
         # check if properties are available
@@ -631,7 +631,7 @@ class AtomsDataSubset(Subset):
         return create_subset(self, subset)
 
     def __getitem__(self, idx):
-        _, properties = self.get_properties(self.indices[idx], self.load_only)
+        _, properties = self.get_properties(idx, self.load_only)
         properties["_idx"] = np.array([idx], dtype=np.int)
 
         return torchify_dict(properties)


### PR DESCRIPTION
Fixes #356

Note that ConcatAtomsData.get_properties(idx, ...) calls get_properties(_idx, ...) on its datasets. The ConcatAtomsData does not know whether the datasets it contains are of type AtomsData or AtomsDataSubset. Thus, if the contained dataset is a AtomsDataSubset, the get_properties function has to accept an _external_ index (just like __getitem__) and not the _internal_ index.
 