### PR TITLE
send 'device' to TorchEnvironmentProvider

### DIFF
--- a/src/schnetpack/utils/script_utils/settings.py
+++ b/src/schnetpack/utils/script_utils/settings.py
@@ -135,7 +135,7 @@ def get_environment_provider(args, device):
         return spk.environment.AseEnvironmentProvider(cutoff=args.cutoff)
     elif args.environment_provider == "torch":
         return spk.environment.TorchEnvironmentProvider(
-            cutoff=args.cutoff, device="cpu"
+            cutoff=args.cutoff, device=device
         )
     else:
         raise NotImplementedError


### PR DESCRIPTION
Pass `device` argument to TorchEnvironmentProvider if one uses `spk_run.py`