### PR TITLE
Fixed energy logging for multiple molecules

### DIFF
--- a/src/schnetpack/md/data/hdf5_data.py
+++ b/src/schnetpack/md/data/hdf5_data.py
@@ -113,7 +113,7 @@ class HDF5Loader:
 
         # Extract energies
         entry_start = 0
-        entry_stop = 1
+        entry_stop = self.n_molecules
         self.properties[f"{properties.energy}_system"] = raw_positions[
             :, :, entry_start:entry_stop
         ].reshape(self.entries, self.n_replicas, self.n_molecules)

--- a/src/schnetpack/md/simulation_hooks/callback_hooks.py
+++ b/src/schnetpack/md/simulation_hooks/callback_hooks.py
@@ -218,7 +218,9 @@ class MoleculeStream(DataStream):
             simulator (schnetpack.md.Simulator): Simulator class used in the molecular dynamics simulation.
         """
         # Account for potential energy and positions
-        data_dimension = 1 + simulator.system.total_n_atoms * 3
+        data_dimension = (
+            simulator.system.n_molecules + simulator.system.total_n_atoms * 3
+        )
 
         # If requested, also store velocities
         if self.store_velocities:
@@ -267,7 +269,7 @@ class MoleculeStream(DataStream):
 
         # Store energies
         start = 0
-        stop = 1
+        stop = simulator.system.n_molecules
         self.buffer[
             buffer_position : buffer_position + 1, :, start:stop
         ] = simulator.system.energy.view(simulator.system.n_replicas, -1).detach()


### PR DESCRIPTION
Fixed buffer dimensions in the `MoleculeStream` of the `FileLogger` to properly handle the energy with multiple molecules.