### PR TITLE
Fixed criterion for recomputing MD neighborlists

### DIFF
--- a/src/schnetpack/md/neighborlist_md.py
+++ b/src/schnetpack/md/neighborlist_md.py
@@ -82,7 +82,7 @@ class NeighborListMD:
             # Check for changes is positions
             update_positions = (
                 torch.norm(self.previous_positions - positions, dim=1)
-                > self.cutoff_shell
+                > 0.5 * self.cutoff_shell
             ).float()
 
             # Map to individual molecules


### PR DESCRIPTION
Fix for issue #397, where a factor of 1/2 was missing from the [displacement criterion](https://github.com/atomistic-machine-learning/schnetpack/blob/50877d89e600f17632b3e3ceb8408954f3f1153e/src/schnetpack/md/neighborlist_md.py#L85) used to determine whether a MD neighborlist should be recomputed.