### PR TITLE
Fix strain

### DIFF
--- a/src/schnetpack/transform/neighborlist.py
+++ b/src/schnetpack/transform/neighborlist.py
@@ -190,7 +190,7 @@ class ASENeighborList(NeighborListTransform):
     """
 
     def _build_neighbor_list(self, Z, positions, cell, pbc, cutoff):
-        at = Atoms(numbers=Z, positions=positions, cell=cell, pbc=pbc)
+        at = Atoms(numbers=Z.detach().numpy(), positions=positions.detach().numpy(), cell=cell.detach().numpy(), pbc=pbc)
 
         idx_i, idx_j, S = neighbor_list("ijS", at, cutoff, self_interaction=False)
         idx_i = torch.from_numpy(idx_i)


### PR DESCRIPTION
To supplement the discussion in #401, here's a fixed version. However, this version does not work with batches of size >1, because I couldn't figure out how to do the broadcasting for the strain. (You need to go from `[batch * 3, 3]` to batch-resolved pairs or positions...)

[Here's a gist](https://gist.github.com/sirmarcel/7b7f4ddb617c10db4a26dd7e75f1aea5) that computes the stress for a toy LJ example with (a) the standard way of straining the positions/box/offset, (b) straining the pair vectors, (c) directly from the pair vectors, and compares with the analytical form implemented in `ase`. The output is this:

```
strain
[[[ -2.6312544  -2.9801838  -8.266836 ]
  [ -2.9801505  -5.8807836 -13.080653 ]
  [ -8.266743  -13.080667  -33.894806 ]]]

strain_rij
[[[ -2.6312795  -2.9801457  -8.266726 ]
  [ -2.9801457  -5.8808045 -13.080628 ]
  [ -8.266726  -13.080628  -33.894817 ]]]

rij
[[[ -2.6312802  -2.9801457  -8.266726 ]
  [ -2.9801457  -5.880803  -13.0806265]
  [ -8.266726  -13.0806265 -33.89482  ]]]

ase
[[ -2.63129346  -2.98017313  -8.2668025 ]
 [ -2.98017313  -5.88085113 -13.08076411]
 [ -8.2668025  -13.08076411 -33.89520126]]
```

Clearly, the implementations all work in principle. Strangely, the standard way appears to be slightly non-symmetric. This is probably a numerical issue, but I'm not 100% sure...

