### PR TITLE
Removed `n_out` argument from `DipoleMoment` and `Polarizability` layer docstrings

### DIFF
--- a/src/schnetpack/atomistic/atomwise.py
+++ b/src/schnetpack/atomistic/atomwise.py
@@ -116,7 +116,6 @@ class DipoleMoment(nn.Module):
         """
         Args:
             n_in: input dimension of representation
-            n_out: output dimension of target property (default: 1)
             n_hidden: size of hidden layers.
                 If an integer, same number of node is used for all hidden layers resulting
                 in a rectangular network.
@@ -232,7 +231,6 @@ class Polarizability(nn.Module):
         """
         Args:
             n_in: input dimension of representation
-            n_out: output dimension of target property (default: 1)
             n_hidden: size of hidden layers.
                 If an integer, same number of node is used for all hidden layers resulting
                 in a rectangular network.


### PR DESCRIPTION
Removed `n_out` argument from `DipoleMoment` and `Polarizability` layer docstrings in `atomwise`, since it is no longer used.