### PR TITLE
Fix correct_charges

### DIFF
--- a/src/schnetpack/atomistic/atomwise.py
+++ b/src/schnetpack/atomistic/atomwise.py
@@ -181,15 +181,13 @@ class DipoleMoment(nn.Module):
         if self.correct_charges:
             if properties.total_charge in inputs:
                 total_charge = inputs[properties.total_charge]
-            else:
-                total_charge = 0.0
 
-            sum_charge = snn.scatter_add(charges, idx_m, dim_size=maxm)
-            charge_correction = (total_charge[:, None] - sum_charge) / natoms.unsqueeze(
-                -1
-            )
-            charge_correction = charge_correction[idx_m]
-            charges = charges + charge_correction
+                sum_charge = snn.scatter_add(charges, idx_m, dim_size=maxm)
+                charge_correction = (total_charge[:, None] - sum_charge) / natoms.unsqueeze(
+                    -1
+                )
+                charge_correction = charge_correction[idx_m]
+                charges = charges + charge_correction
 
         if self.return_charges:
             inputs[self.charges_key] = charges


### PR DESCRIPTION
If total_charge is not in properties total_charge would be set to 0.0 which would crash at "total_charge[:, None]" with TypeError: 'float' object is not subscriptable