### PR TITLE
Fixed inverted grad context for calculator

### DIFF
--- a/src/schnetpack/md/calculators/base_calculator.py
+++ b/src/schnetpack/md/calculators/base_calculator.py
@@ -98,9 +98,9 @@ class MDCalculator(nn.Module):
 
         # set up gradient context for passing results
         if gradients_required:
-            self.grad_context = torch.no_grad()
-        else:
             self.grad_context = nullcontext()
+        else:
+            self.grad_context = torch.no_grad()
 
     def calculate(self, system: System):
         """

--- a/src/schnetpack/md/calculators/schnetpack_calculator.py
+++ b/src/schnetpack/md/calculators/schnetpack_calculator.py
@@ -116,7 +116,7 @@ class SchNetPackCalculator(MDCalculator):
                 if isinstance(pp, schnetpack.transform.AddOffsets):
                     log.info("Found `AddOffsets` postprocessing module...")
                     log.info(
-                        "Constant offset of {:20.11f} will be removed...".format(
+                        "Constant offset of {:20.11f} per atom  will be removed...".format(
                             pp.mean.detach().cpu().numpy()
                         )
                     )

--- a/src/schnetpack/md/md_configs/dynamics/thermostat/pile_local.yaml
+++ b/src/schnetpack/md/md_configs/dynamics/thermostat/pile_local.yaml
@@ -1,3 +1,3 @@
-_target_: schnetpack.md.simulation_hooks.PILEGlobalThermostat
+_target_: schnetpack.md.simulation_hooks.PILELocalThermostat
 temperature_bath: 300.0 # K
 time_constant: 100.0 # fs


### PR DESCRIPTION
Fixed a bug in the `MDCalculator` where the wrong gradient context was used when enabling gradient accumulation and vice versa.