### PR TITLE
Fix load_properties

### DIFF
--- a/src/schnetpack/data/datamodule.py
+++ b/src/schnetpack/data/datamodule.py
@@ -176,6 +176,7 @@ class AtomsDataModule(pl.LightningDataModule):
                 self.format,
                 property_units=self.property_units,
                 distance_unit=self.distance_unit,
+                load_properties=self.load_properties,
             )
 
             # load and generate partitions if needed


### PR DESCRIPTION
Fixed an error where all properties in the database were loaded instead of the ones specified in load_properties: load_properties is now properly passed to load_dataset