### PR TITLE
Make return of vector representation in SO3net optional

### DIFF
--- a/src/schnetpack/configs/model/representation/so3net.yaml
+++ b/src/schnetpack/configs/model/representation/so3net.yaml
@@ -7,6 +7,7 @@ n_atom_basis: 128
 n_interactions: 3
 lmax: 2
 shared_interactions: False
+return_vector_representation: False
 cutoff_fn:
   _target_: schnetpack.nn.cutoff.CosineCutoff
   cutoff: ${globals.cutoff}


### PR DESCRIPTION
Output of the Cartesian vector representation in the `SO3net` representation can now be controlled with the  `return_vector_representation` option.

Returning the Cartesian vector representation by default can lead to unwanted memory overhead, especially for bulk systems. Due to this, `return_vector_features` is now disabled by default in the `so3net` config.
