### PR TITLE
Update default_run.yaml

### DIFF
--- a/src/schnetpack/configs/run/default_run.yaml
+++ b/src/schnetpack/configs/run/default_run.yaml
@@ -1,5 +1,5 @@
 work_dir: ${hydra:runtime.cwd}
 data_dir: ${run.work_dir}/data
-path: runs
+path: ${run.work_dir}/runs
 experiment: default
 id: ${uuid:1}


### PR DESCRIPTION
To be in line with `run.data_dir`, the field `run.path` now is a subdirectory of `run.work_dir` in the default setting.