### PR TITLE
fix: add support for force models in spkpredict

### DIFF
--- a/src/schnetpack/configs/predict.yaml
+++ b/src/schnetpack/configs/predict.yaml
@@ -8,6 +8,8 @@ outputdir: ???
 cutoff: ???
 batch_size: 100
 write_interval: epoch
+enable_grad: false
+write_idx_m: false
 
 data:
   _target_: schnetpack.data.ASEAtomsData


### PR DESCRIPTION
`spkpredict` was not working well on force models.
fixes:
- allows gradient computation for force predictions (use with enable_grad=True)
- writes idx_m values, so force predictions can be assigned to structure ids (use with write_idx_m=True)
- concatenate results 