### PR TITLE
Sh/spkpredict

### DIFF
--- a/src/schnetpack/cli.py
+++ b/src/schnetpack/cli.py
@@ -194,6 +194,7 @@ def predict(config: DictConfig):
             torch.set_grad_enabled(self.enable_grad)
             results = self(batch)
             results[properties.idx_m] = batch[properties.idx][batch[properties.idx_m]]
+            results = {k: v.detach().cpu() for k, v in results.items()}
             return results
 
 

--- a/src/schnetpack/cli.py
+++ b/src/schnetpack/cli.py
@@ -182,7 +182,7 @@ def predict(config: DictConfig):
     model = torch.load("best_model")
 
     class WrapperLM(LightningModule):
-        def __init__(self, model, enable_grad=False):
+        def __init__(self, model, enable_grad=config.enable_grad):
             super().__init__()
             self.model = model
             self.enable_grad = enable_grad


### PR DESCRIPTION
two small fixes for spkpredict:
- bug: removed hardcoded argument in `WrapperLM`
- detach predicted properties and move to CPU to avoid memory issues 