### PR TITLE
Removed deprecated arguments …

### DIFF
--- a/src/schnetpack/cli.py
+++ b/src/schnetpack/cli.py
@@ -212,5 +212,5 @@ def predict(config: DictConfig):
     trainer.predict(
         WrapperLM(model, config.enable_grad),
         dataloaders=loader,
-        ckpt_path="checkpoints/last.ckpt",
+        ckpt_path=config.ckpt_path,
     )

--- a/src/schnetpack/cli.py
+++ b/src/schnetpack/cli.py
@@ -74,13 +74,13 @@ def train(config: DictConfig):
             OmegaConf.save(old_config, f, resolve=False)
 
         # resume from latest checkpoint
-        if config.trainer.resume_from_checkpoint is None:
+        if config.run.ckpt_path is None:
             if os.path.exists("checkpoints/last.ckpt"):
-                config.trainer.resume_from_checkpoint = "checkpoints/last.ckpt"
+                config.run.ckpt_path = "checkpoints/last.ckpt"
 
-        if config.trainer.resume_from_checkpoint is not None:
+        if config.run.ckpt_path is not None:
             log.info(
-                f"Resuming from checkpoint {os.path.abspath(config.trainer.resume_from_checkpoint)}"
+                f"Resuming from checkpoint {os.path.abspath(config.run.ckpt_path)}"
             )
     else:
         with open("config.yaml", "w") as f:
@@ -155,7 +155,7 @@ def train(config: DictConfig):
 
     # Train the model
     log.info("Starting training.")
-    trainer.fit(model=task, datamodule=datamodule)
+    trainer.fit(model=task, datamodule=datamodule, ckpt_path=config.run.ckpt_path)
 
     # Evaluate model on test set after training
     log.info("Starting testing.")
@@ -207,7 +207,10 @@ def predict(config: DictConfig):
             )
         ],
         default_root_dir=".",
-        resume_from_checkpoint="checkpoints/last.ckpt",
         _convert_="partial",
     )
-    trainer.predict(WrapperLM(model, config.enable_grad), dataloaders=loader)
+    trainer.predict(
+        WrapperLM(model, config.enable_grad),
+        dataloaders=loader,
+        ckpt_path="checkpoints/last.ckpt",
+    )

--- a/src/schnetpack/configs/predict.yaml
+++ b/src/schnetpack/configs/predict.yaml
@@ -6,6 +6,7 @@ datapath: ???
 modeldir: ???
 outputdir: ???
 cutoff: ???
+ckpt_path: null
 batch_size: 100
 write_interval: epoch
 enable_grad: false

--- a/src/schnetpack/configs/run/default_run.yaml
+++ b/src/schnetpack/configs/run/default_run.yaml
@@ -3,3 +3,4 @@ data_dir: ${run.work_dir}/data
 path: ${run.work_dir}/runs
 experiment: default
 id: ${uuid:1}
+ckpt_path: null

--- a/src/schnetpack/configs/trainer/default_trainer.yaml
+++ b/src/schnetpack/configs/trainer/default_trainer.yaml
@@ -23,13 +23,9 @@ limit_test_batches: 1.0
 track_grad_norm: -1
 detect_anomaly: False
 
-amp_backend: "native"
-amp_level: null
 precision: 32
 accelerator: auto
 num_nodes: 1
 tpu_cores: null
 deterministic: False
 inference_mode: False
-
-resume_from_checkpoint: null


### PR DESCRIPTION
…'amp_backend', 'amp_level', and 'resume_from_checkpoint' from trainer config. Added 'ckpt_path' to run config as a replacement for 'trainer.resume_from_checkpoint' and adapted the cli script accordingly.