### PR TITLE
hydra: add _self_ to defaults list to avoid warning

### DIFF
--- a/src/schnetpack/configs/predict.yaml
+++ b/src/schnetpack/configs/predict.yaml
@@ -1,5 +1,6 @@
 # @package _global_
 defaults:
+  - _self_
   - trainer: default_trainer
 
 datapath: ???

--- a/src/schnetpack/configs/train.yaml
+++ b/src/schnetpack/configs/train.yaml
@@ -1,6 +1,7 @@
 # @package _global_
 
 defaults:
+  - _self_
   - run: default_run
   - globals: default_globals
   - trainer: default_trainer

--- a/src/schnetpack/md/md_configs/config.yaml
+++ b/src/schnetpack/md/md_configs/config.yaml
@@ -9,6 +9,7 @@ restart: null
 load_config: null
 
 defaults:
+  - _self_
   - calculator: spk
   - system: system
   - dynamics: base


### PR DESCRIPTION
Hydra 1.1 changes the order in which values in the defaults list are overridden:

https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/default_composition_order/

None of the configs I found in schnetpack is affected by this but in order to make it clear to hydra that we're aware of this issue, we can add _self_ at the beginning of the defaults list. This avoids a warning on every run.