### PR TITLE
doc: put link to docs earlier in the readme, and add tests README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 SchNetPack is a toolbox for the development and application of deep neural networks to the prediction of potential energy surfaces and other quantum-chemical properties of molecules and materials. It contains basic building blocks of atomistic neural networks, manages their training and provides simple access to common benchmark datasets. This allows for an easy implementation and evaluation of new models.
 
+The documentation can be found [here](https://schnetpack.readthedocs.io).
+
 ##### Features
 
 - SchNet - an end-to-end continuous-filter CNN for molecules and materials [1-3]
@@ -206,9 +208,6 @@ SchNetPack can be used as a base for implementations of advanced atomistic neura
 For example, there exists an [extension package](https://github.com/atomistic-machine-learning/schnetpack-gschnet) called `schnetpack-gschnet` for the most recent version of cG-SchNet [5], a conditional generative model for molecules.
 It demonstrates how a complex training task can be implemented in a few custom classes while leveraging the hierarchical configuration and automated training procedure of the SchNetPack framework.
 
-## Documentation
-
-For the full API reference, visit our [documentation](https://schnetpack.readthedocs.io).
 
 ## Citation
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,21 @@
+# Test suite
+
+SchNetPack has unit tests that you can run to make sure that everything is working properly.
+
+## Test dependencies
+To install the additional test dependencies, install with:
+```
+pip install schnetpack[test]
+```
+
+Or, if you installed from source and assuming you are in your local copy of the SchNetPack repository,
+```
+pip install .[test]
+```
+
+## Run tests
+In order to run the tests, switch into the `tests` directory and run the `pytest` command:
+```
+cd tests
+pytest
+```


### PR DESCRIPTION
I think the link from the Readme to the docs should be very prominent, so I placed it earlier in the Readme.

Also, I started a Readme on how to run the tests in the `tests` folder.