### PR TITLE
provide batch size to self.log() of lightning module to prevent warning

### DIFF
--- a/src/schnetpack/task.py
+++ b/src/schnetpack/task.py
@@ -202,7 +202,7 @@ class AtomisticTask(pl.LightningModule):
 
         loss = self.loss_fn(pred, targets)
 
-        self.log("val_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.log("val_loss", loss, on_step=False, on_epoch=True, prog_bar=True, batch_size=len(batch['_idx']))
         self.log_metrics(pred, targets, "val")
 
         return {"val_loss": loss}
@@ -225,7 +225,7 @@ class AtomisticTask(pl.LightningModule):
 
         loss = self.loss_fn(pred, targets)
 
-        self.log("test_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.log("test_loss", loss, on_step=False, on_epoch=True, prog_bar=True, batch_size=len(batch['_idx']))
         self.log_metrics(pred, targets, "test")
         return {"test_loss": loss}
 


### PR DESCRIPTION
this gets rid of annoying warnings of the form
```
/usr/local/lib/python3.11/site-packages/pytorch_lightning/utilities/data.py:77:
Trying to infer the `batch_size` from an ambiguous collection.
The batch size we found is 100. To avoid any miscalculations,
use `self.log(..., batch_size=batch_size)`.
```
I assume/hope `batch['_idx']` is always available?