### PR TITLE
Ignore model hyperparameters when saving because they are saved at checkpointing

### DIFF
--- a/src/schnetpack/task.py
+++ b/src/schnetpack/task.py
@@ -129,7 +129,7 @@ class AtomisticTask(pl.LightningModule):
         self.grad_enabled = len(self.model.required_derivatives) > 0
         self.lr = optimizer_args["lr"]
         self.warmup_steps = warmup_steps
-        self.save_hyperparameters()
+        self.save_hyperparameters(ignore=['model'])
 
     def setup(self, stage=None):
         if stage == "fit":


### PR DESCRIPTION
This avoids a warning during training, and probably saves some disk space.
I just ran a training and afterwards an MD with this patch applied and didn't observe problems.