### PR TITLE
fixed device (cpu) in qm9 tutorial

### DIFF
--- a/examples/tutorials/tutorial_02_qm9.ipynb
+++ b/examples/tutorials/tutorial_02_qm9.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -56,28 +56,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "rm: cannot remove 'split.npz': No such file or directory\r\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 10/10 [00:06<00:00,  1.57it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%rm split.npz\n",
     "\n",
@@ -118,23 +103,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "U0 of hyrogen: -13.613121032714844 eV\n",
-      "U0 of carbon: -1029.863037109375 eV\n",
-      "U0 of oxygen: -2042.611083984375 eV\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "atomrefs = qm9data.train_dataset.atomrefs\n",
     "print('U0 of hyrogen:', atomrefs[QM9.U0][1].item(), 'eV')\n",
@@ -159,22 +134,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mean atomization energy / atom: -4.247325399125455\n",
-      "Std. dev. atomization energy / atom: 0.1801580985912772\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "means, stddevs = qm9data.get_stats(\n",
     "    QM9.U0, divide_by_atoms=True, remove_atomref=True\n",
@@ -211,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -263,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -302,24 +268,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:torch.distributed.nn.jit.instantiator:Created a temporary directory at /tmp/tmpsaotd4ge\n",
-      "INFO:torch.distributed.nn.jit.instantiator:Writing /tmp/tmpsaotd4ge/_remote_module_non_sriptable.py\n",
-      "/home/kschuett/anaconda3/envs/spkdev/lib/python3.8/site-packages/pytorch_lightning/utilities/parsing.py:268: UserWarning: Attribute 'model' is an instance of `nn.Module` and is already saved during checkpointing. It is recommended to ignore them using `self.save_hyperparameters(ignore=['model'])`.\n",
-      "  rank_zero_warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "task = spk.task.AtomisticTask(\n",
     "    model=nnpot,\n",
@@ -347,117 +302,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "GPU available: True (cuda), used: False\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "IPU available: False, using: 0 IPUs\n",
-      "HPU available: False, using: 0 HPUs\n",
-      "/home/kschuett/anaconda3/envs/spkdev/lib/python3.8/site-packages/pytorch_lightning/trainer/trainer.py:1764: PossibleUserWarning: GPU available but not used. Set `accelerator` and `devices` using `Trainer(accelerator='gpu', devices=1)`.\n",
-      "  rank_zero_warn(\n",
-      "\n",
-      "  | Name    | Type                   | Params\n",
-      "---------------------------------------------------\n",
-      "0 | model   | NeuralNetworkPotential | 16.4 K\n",
-      "1 | outputs | ModuleList             | 0     \n",
-      "---------------------------------------------------\n",
-      "16.4 K    Trainable params\n",
-      "0         Non-trainable params\n",
-      "16.4 K    Total params\n",
-      "0.066     Total estimated model params size (MB)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "Sanity Checking: 0it [00:00, ?it/s]",
-      "application/vnd.jupyter.widget-view+json": {
-       "version_major": 2,
-       "version_minor": 0,
-       "model_id": "bb3ac9516922417a92ce5bbbc9906f28"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/kschuett/anaconda3/envs/spkdev/lib/python3.8/site-packages/pytorch_lightning/trainer/connectors/data_connector.py:236: PossibleUserWarning: The dataloader, val_dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 8 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
-      "  rank_zero_warn(\n",
-      "/home/kschuett/anaconda3/envs/spkdev/lib/python3.8/site-packages/pytorch_lightning/utilities/data.py:98: UserWarning: Trying to infer the `batch_size` from an ambiguous collection. The batch size we found is 100. To avoid any miscalculations, use `self.log(..., batch_size=batch_size)`.\n",
-      "  warning_cache.warn(\n",
-      "/home/kschuett/anaconda3/envs/spkdev/lib/python3.8/site-packages/pytorch_lightning/trainer/connectors/data_connector.py:236: PossibleUserWarning: The dataloader, train_dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 8 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
-      "  rank_zero_warn(\n",
-      "/home/kschuett/anaconda3/envs/spkdev/lib/python3.8/site-packages/pytorch_lightning/trainer/trainer.py:1892: PossibleUserWarning: The number of training batches (10) is smaller than the logging interval Trainer(log_every_n_steps=50). Set a lower value for log_every_n_steps if you want to see logs for the training epoch.\n",
-      "  rank_zero_warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "Training: 0it [00:00, ?it/s]",
-      "application/vnd.jupyter.widget-view+json": {
-       "version_major": 2,
-       "version_minor": 0,
-       "model_id": "a3dfe943394e46ea9c2f8650e1d21041"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": "Validation: 0it [00:00, ?it/s]",
-      "application/vnd.jupyter.widget-view+json": {
-       "version_major": 2,
-       "version_minor": 0,
-       "model_id": "fc72ad793efd412cbcb6f9faa830dfda"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": "Validation: 0it [00:00, ?it/s]",
-      "application/vnd.jupyter.widget-view+json": {
-       "version_major": 2,
-       "version_minor": 0,
-       "model_id": "420695c4425f4c7d8e7c38f8baed25a7"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": "Validation: 0it [00:00, ?it/s]",
-      "application/vnd.jupyter.widget-view+json": {
-       "version_major": 2,
-       "version_minor": 0,
-       "model_id": "febc0505aa174edfb9f3c5ab275f548b"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "`Trainer.fit` stopped: `max_epochs=3` reached.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "logger = pl.loggers.TensorBoardLogger(save_dir=qm9tut)\n",
     "callbacks = [\n",
@@ -511,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -523,7 +374,7 @@
     "import numpy as np\n",
     "from ase import Atoms\n",
     "\n",
-    "best_model = torch.load(os.path.join(qm9tut, 'best_inference_model'))"
+    "best_model = torch.load(os.path.join(qm9tut, 'best_inference_model'), map_location=\"cpu\")"
    ]
   },
   {
@@ -539,41 +390,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result dictionary: {'energy_U0': tensor([-11901.9678, -10829.1715, -10493.9096, -11365.3375,  -9995.8116,\n",
-      "        -10451.7412, -10851.2470, -11006.8458, -10494.9420, -11368.3874,\n",
-      "         -8844.8229, -11902.6537,  -9918.1257,  -9956.3337, -10833.8384,\n",
-      "        -12016.3231, -12344.6808, -11981.6151, -11842.0390, -10573.4037,\n",
-      "        -10930.8419, -10414.9862, -10340.3468, -11508.4475, -10553.1781,\n",
-      "        -11464.8257, -11010.9114, -10573.8298, -11546.2505, -10398.0184,\n",
-      "        -11901.8865, -12382.0646, -11805.9859, -11468.2166, -12303.6954,\n",
-      "        -11982.0471, -11942.9695, -10972.0845, -12742.0990, -12305.2618,\n",
-      "         -9995.6813, -11326.8686, -13931.4072, -10534.4627, -11945.2061,\n",
-      "        -12557.3998, -11943.9106, -10568.2193, -11538.0142, -10492.3288,\n",
-      "         -9857.8994, -11368.2026, -11506.9391, -10965.4910, -10973.1663,\n",
-      "        -11584.8918, -11503.7264, -12990.9329, -12518.4351, -11543.0566,\n",
-      "        -11408.7530, -11942.5794, -13317.8285,  -9597.8316, -10930.5504,\n",
-      "        -12460.0102, -11802.8971, -10395.8514, -13355.2561,  -9478.2067,\n",
-      "         -5291.8420, -10411.8928, -11804.3231, -11766.3743, -10532.8525,\n",
-      "         -9604.8805, -12478.7421, -11747.7678, -11368.4521,  -9609.7054,\n",
-      "        -12381.6398, -10635.5377, -11867.4939, -11767.7288, -10473.4594,\n",
-      "        -11267.5563, -11845.0998, -12304.8664, -11582.9844, -11542.7391,\n",
-      "        -10531.9801, -10973.6226, -11403.2258, -10489.5223, -11585.6760,\n",
-      "        -10929.6288, -11908.0952, -12917.9566,  -9458.0325, -13433.7984],\n",
-      "       dtype=torch.float64, grad_fn=<AddBackward0>)}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for batch in qm9data.test_dataloader():\n",
     "    result = best_model(batch)\n",
@@ -595,7 +418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -608,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -627,22 +450,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Keys: ['_n_atoms', '_atomic_numbers', '_positions', '_cell', '_pbc', '_idx', '_idx_i_local', '_idx_j_local', '_offsets', '_idx_m', '_idx_i', '_idx_j']\n",
-      "Prediction: tensor([-1103.2246], dtype=torch.float64, grad_fn=<AddBackward0>)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "inputs = converter(atoms)\n",
     "\n",
@@ -666,28 +480,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:schnetpack.interfaces.ase_interface:Loading model from ./qm9tut/best_inference_model\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Prediction: -1103.2246329784393\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "calculator = spk.interfaces.SpkCalculator(\n",
     "    model_file=os.path.join(qm9tut, \"best_inference_model\"), # path to model\n",
@@ -732,7 +531,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.12"
   },
   "nbsphinx": {
    "execute": "never"


### PR DESCRIPTION
the tutorial would return an error in the inference part in case the model has been trained on a cuda device.
Now the device for inference is fixed to cpu

PRs with notebooks are usually very cluttered. I cleared all the outputs to avoid this in the future.