### PR TITLE
fixes bug and updates to new simpy verison

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ license = { file="LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=2.0.0",
-    "sympy",
+    "sympy<=1.12",
     "ase>=3.21",
     "h5py",
     "pyyaml",
@@ -36,8 +36,8 @@ dependencies = [
     "dirsync",
     "torch-ema",
     "matscipy>=1.1.0",
-    "tensorboard",
-    "tensorboardX",
+    "tensorboard>=2.17.1",
+    "tensorboardX>=2.6.2.2",
     "tqdm",
     "pre-commit",
     "black",

--- a/src/schnetpack/nn/ops/so3.py
+++ b/src/schnetpack/nn/ops/so3.py
@@ -54,8 +54,8 @@ def generate_clebsch_gordan(lmax: int) -> torch.Tensor:
     """
     lidx, midx = sh_indices(lmax)
     cg = torch.zeros((lidx.shape[0], lidx.shape[0], lidx.shape[0]))
-    lidx = lidx
-    midx = midx
+    lidx = lidx.numpy()
+    midx = midx.numpy()
     for c1, (l1, m1) in enumerate(zip(lidx, midx)):
         for c2, (l2, m2) in enumerate(zip(lidx, midx)):
             for c3, (l3, m3) in enumerate(zip(lidx, midx)):

--- a/src/schnetpack/nn/ops/so3.py
+++ b/src/schnetpack/nn/ops/so3.py
@@ -54,8 +54,8 @@ def generate_clebsch_gordan(lmax: int) -> torch.Tensor:
     """
     lidx, midx = sh_indices(lmax)
     cg = torch.zeros((lidx.shape[0], lidx.shape[0], lidx.shape[0]))
-    lidx = lidx.numpy()
-    midx = midx.numpy()
+    lidx = lidx
+    midx = midx
     for c1, (l1, m1) in enumerate(zip(lidx, midx)):
         for c2, (l2, m2) in enumerate(zip(lidx, midx)):
             for c3, (l3, m3) in enumerate(zip(lidx, midx)):

--- a/src/schnetpack/representation/so3net.py
+++ b/src/schnetpack/representation/so3net.py
@@ -130,7 +130,7 @@ class SO3net(nn.Module):
         x0 = self.embedding(atomic_numbers)
         for embedding in self.electronic_embeddings:
             x0 = x0 + embedding(x0, inputs)
-        x0 = x0.unsueeze(1)
+        x0 = x0.unsqueeze(1)
 
         # compute interaction blocks and update atomic embeddings
         x = so3.scalar2rsh(x0, int(self.lmax))


### PR DESCRIPTION
* New `simpy` version caused problems with `numpy` inputs (`ValueError('expecting integer or half-integer, got 0')`). Just using the `torch` tensors instead solves the issue and prevents an unnecessary conversion from `torch` to `numpy` 

* Fixes a typo