### PR TITLE
fix dataset split into train/val/test

### DIFF
--- a/src/schnetpack/data/splitting.py
+++ b/src/schnetpack/data/splitting.py
@@ -48,13 +48,13 @@ def random_split(dsize: int, *split_sizes: Union[int, float]) -> List[torch.tens
 
     Args:
         dsize - Size of dataset.
-        split_sizes - Sizes for each split. One can be set to -1 to assign all
-            remaining data. Values in [0, 1] can be used to give relative partition
+        split_sizes - Sizes for each split. One value can be set to None to assign all
+            remaining data. Values in [0, 1) can be used to give relative partition
             sizes.
     """
     split_sizes = absolute_split_sizes(dsize, split_sizes)
     offsets = torch.cumsum(torch.tensor(split_sizes), dim=0)
-    indices = torch.randperm(sum(split_sizes)).tolist()
+    indices = torch.randperm(dsize).tolist()
     partition_sizes_idx = [
         indices[offset - length : offset]
         for offset, length in zip(offsets, split_sizes)


### PR DESCRIPTION
There's a bug that only occurs if `data.num_test` is *not* None (it is None by default).

Currently, the indices for train/val/test are only picked from the first `num_train + num_val + num_test` samples in the dataset. For instance, if I set all of the three values to 1, then the only dataset indices considered will be 0, 1, 2.

Also the docstring had some issues.