### PR TITLE
cli.py: fix error message with correct recommendation

### DIFF
--- a/src/schnetpack/cli.py
+++ b/src/schnetpack/cli.py
@@ -57,7 +57,7 @@ def train(config: DictConfig):
             f"""
         Config incomplete! You have to specify at least `data` and `model`!
         For an example, try one of our pre-defined experiments:
-        > spktrain data_dir=/data/will/be/here +experiment=qm9
+        > spktrain experiment=qm9_atomwise
         """
         )
         return


### PR DESCRIPTION
The current recommendation does not work, also specifying the data_dir is not necessary.