### PR TITLE
[Bug] `GroupSplit` missing in QM7X dataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
     "tqdm",
     "pre-commit",
     "black",
-    "protobuf"
+    "protobuf",
+    "progressbar"
 ]
 
 [project.optional-dependencies]

--- a/src/schnetpack/data/splitting.py
+++ b/src/schnetpack/data/splitting.py
@@ -14,7 +14,7 @@ def absolute_split_sizes(dsize: int, split_sizes: List[int]) -> List[int]:
         dsize - Size of dataset.
         split_sizes - Sizes for each split. One can be set to -1 to assign all
             remaining data.
-    """ 
+    """
     none_idx = None
     split_sizes = list(split_sizes)
     psum = 0

--- a/src/schnetpack/data/splitting.py
+++ b/src/schnetpack/data/splitting.py
@@ -3,7 +3,7 @@ import math
 import torch
 import numpy as np
 
-__all__ = ["SplittingStrategy", "RandomSplit", "SubsamplePartitions"]
+__all__ = ["SplittingStrategy", "RandomSplit", "SubsamplePartitions", "GroupSplit"]
 
 
 def absolute_split_sizes(dsize: int, split_sizes: List[int]) -> List[int]:
@@ -14,7 +14,7 @@ def absolute_split_sizes(dsize: int, split_sizes: List[int]) -> List[int]:
         dsize - Size of dataset.
         split_sizes - Sizes for each split. One can be set to -1 to assign all
             remaining data.
-    """
+    """ 
     none_idx = None
     split_sizes = list(split_sizes)
     psum = 0


### PR DESCRIPTION
# General

Hi all. Thanks for the work on this project. I noticed two issues while working with the QM7X dataset:
- Missing symbol export from splitters.py (missing `GroupSplit` used by the `QM7X` dataset)
- Missing requirement for `progressbar` (only used in `QM7X`)

# Details

## Minimal Working Example

```python
from schnetpack.datasets import qm7x

data = qm7x.QM7X(
    datapath="QM7X.db",
    raw_data_path="./",
    batch_size=10,
    num_train=10000,
    num_val=10000,
    num_test=10000,
)
data.prepare_data()
print(data)
```

Error:
```
Traceback (most recent call last):
  File "/home/james.smith/apps/qcog-orionis/2025-01-27/qm7x.py", line 3, in <module>
    data = qm7x.QM7X(
           ^^^^^^^^^^
  File "/home/james.smith/apps/schnetpack/src/schnetpack/datasets/qm7x.py", line 237, in __init__
    splitting=splitting or GroupSplit(splitting_key="smiles_id"),
                           ^^^^^^^^^^
NameError: name 'GroupSplit' is not defined
```

# Next Steps

I'm happy to make adjustments, just let me know what you think.

All the best,
James