### PR TITLE
fix bug in python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 description = "SchNetPack - Deep Neural Networks for Atomistic Systems"
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = "==3.12"
+requires-python = ">=3.12,<3.13"
 dependencies = [
     "numpy>=2.0.0",
     "sympy>=1.13",


### PR DESCRIPTION
`"==3.12"` does not allow any `"==3.12.x"` versions