### PR TITLE
Fix connection error when `load_properties` is not None

### DIFF
--- a/src/schnetpack/data/atoms.py
+++ b/src/schnetpack/data/atoms.py
@@ -214,6 +214,10 @@ class ASEAtomsData(BaseAtomsData):
                 of the dataset. Units are converted automatically during loading.
         """
         self.datapath = datapath
+        if not os.path.exists(self.datapath):
+            raise AtomsDataError(f"ASE DB does not exists at {self.datapath}")
+
+        self.conn = connect(self.datapath, use_lock_file=False)
 
         BaseAtomsData.__init__(
             self,
@@ -224,7 +228,6 @@ class ASEAtomsData(BaseAtomsData):
         )
 
         self._check_db()
-        self.conn = connect(self.datapath, use_lock_file=False)
 
         # initialize units
         md = self.metadata


### PR DESCRIPTION
The removal of redundant connections  #686 had unforeseen consequences if `load_properties` is specified.

If `load_properties` is provided during creation of `ASEAtomsData` classes, and as a result also during creation of `AtomsDataModule`s, an Attribute error is thrown.

```Python
from schnetpack.datasets import QM9
from schnetpack.transform import ASENeighborList

qm9data = QM9(
    './qm9.db', 
    batch_size=10,
    num_train=110000,
    num_val=10000,
    split_file='./split_qm9.npz', 
    transforms=[ASENeighborList(cutoff=5.)], load_properties=[QM9.lumo]
)
qm9data.prepare_data()
qm9data.setup()
```

throws:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[1], line 13
      4 qm9data = QM9(
      5     './qm9.db', 
      6     batch_size=10,
   (...)     10     transforms=[ASENeighborList(cutoff=5.)], load_properties=[QM9.lumo]
     11 )
     12 qm9data.prepare_data()
---> 13 qm9data.setup()

File ~/python_packages/schnet_pub/src/schnetpack/data/datamodule.py:184, in AtomsDataModule.setup(self, stage)
    182 # (re)load datasets
    183 if self.dataset is None:
--> 184     self.dataset = load_dataset(
    185         datapath,
    186         self.format,
    187         property_units=self.property_units,
    188         distance_unit=self.distance_unit,
    189         load_properties=self.load_properties,
    190     )
    192     # load and generate partitions if needed
    193     if self.train_idx is None:

File ~/python_packages/schnet_pub/src/schnetpack/data/atoms.py:598, in load_dataset(datapath, format, **kwargs)
    588 """
    589 Load dataset.
    590 
   (...)    595 
    596 """
    597 if format is AtomsDataFormat.ASE:
--> 598     dataset = ASEAtomsData(datapath=datapath, **kwargs)
    599 else:
    600     raise AtomsDataError(f"Unknown format: {format}")

File ~/python_packages/schnet_pub/src/schnetpack/data/atoms.py:218, in ASEAtomsData.__init__(self, datapath, load_properties, load_structure, transforms, subset_idx, property_units, distance_unit)
    205 """
    206 Args:
    207     datapath: Path to ASE DB.
   (...)    214         of the dataset. Units are converted automatically during loading.
    215 """
    216 self.datapath = datapath
--> 218 BaseAtomsData.__init__(
    219     self,
    220     load_properties=load_properties,
    221     load_structure=load_structure,
    222     transforms=transforms,
    223     subset_idx=subset_idx,
    224 )
    226 self._check_db()
    227 self.conn = connect(self.datapath, use_lock_file=False)

File ~/python_packages/schnet_pub/src/schnetpack/data/atoms.py:76, in BaseAtomsData.__init__(self, load_properties, load_structure, transforms, subset_idx)
     67 """
     68 Args:
     69     load_properties: Set of properties to be loaded and returned.
   (...)     73     subset: List of data indices.
     74 """
     75 self._transform_module = None
---> 76 self.load_properties = load_properties
     77 self.load_structure = load_structure
     78 self.transforms = transforms

File ~/python_packages/schnet_pub/src/schnetpack/data/atoms.py:132, in BaseAtomsData.load_properties(self, val)
    129 @load_properties.setter
    130 def load_properties(self, val: List[str]):
    131     if val is not None:
--> 132         props = self.available_properties
    133         assert all(
    134             [p in props for p in val]
    135         ), "Not all given properties are available in the dataset!"
    136     self._load_properties = val

File ~/python_packages/schnet_pub/src/schnetpack/data/atoms.py:385, in ASEAtomsData.available_properties(self)
    383 @property
    384 def available_properties(self) -> List[str]:
--> 385     md = self.metadata
    386     return list(md["_property_unit_dict"].keys())

File ~/python_packages/schnet_pub/src/schnetpack/data/atoms.py:369, in ASEAtomsData.metadata(self)
    367 @property
    368 def metadata(self):
--> 369     return self.conn.metadata

AttributeError: 'ASEAtomsData' object has no attribute 'conn'
```

This pull request fixes the error by creating the connection earlier. The additional file check ensures that no spurious empty databases are created.
