### PR TITLE
Sh/petnames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ dependencies = [
     "black[jupyter]",
     "protobuf",
     "progressbar",
-    "pytest"
+    "pytest",
+    "petname",
 ]
 
 [project.optional-dependencies]

--- a/src/schnetpack/cli.py
+++ b/src/schnetpack/cli.py
@@ -5,6 +5,7 @@ import tempfile
 import socket
 from typing import List
 import random
+import petname
 
 import torch
 import hydra
@@ -26,6 +27,7 @@ log = logging.getLogger(__name__)
 
 
 OmegaConf.register_new_resolver("uuid", lambda x: str(uuid.uuid1()))
+OmegaConf.register_new_resolver("petname", lambda x: petname.generate())
 OmegaConf.register_new_resolver("tmpdir", tempfile.mkdtemp, use_cache=True)
 
 header = """

--- a/src/schnetpack/configs/experiment/qm9_atomwise.yaml
+++ b/src/schnetpack/configs/experiment/qm9_atomwise.yaml
@@ -6,6 +6,7 @@ defaults:
 
 run:
   experiment: qm9_${globals.property}
+  id: ${petname:1}
 
 globals:
   cutoff: 5.

--- a/src/schnetpack/configs/experiment/qm9_atomwise.yaml
+++ b/src/schnetpack/configs/experiment/qm9_atomwise.yaml
@@ -6,7 +6,6 @@ defaults:
 
 run:
   experiment: qm9_${globals.property}
-  id: ${petname:1}
 
 globals:
   cutoff: 5.


### PR DESCRIPTION
Added a new `OmegaConf` resolver that generates unique model directories with cute petnames instead of random strings.

Example use:
`run.id: ${uuid:1}` -> `runs/0b504ffc-dd84-11ef-b113-7e8ae1cdf899`

 `run.id: ${petname:1}` -> `runs/funny-walrus`
