### PR TITLE
fix(neighborlist): use weights_only=True in torch.load to avoid future torch breakage

### DIFF
--- a/src/schnetpack/transform/neighborlist.py
+++ b/src/schnetpack/transform/neighborlist.py
@@ -105,8 +105,8 @@ class CachedNeighborList(Transform):
 
         # try to read cached NBL
         try:
-            data = torch.load(cache_file)
-            inputs.update(data)
+            data = torch.load(cache_file, weights_only=True)
+            inputs.update(data, weights_only=True)
         except IOError:
             # acquire lock for caching
             lock = fasteners.InterProcessLock(
@@ -117,7 +117,7 @@ class CachedNeighborList(Transform):
             with lock:
                 # retry reading, in case other process finished in the meantime
                 try:
-                    data = torch.load(cache_file)
+                    data = torch.load(cache_file, weights_only=True)
                     inputs.update(data)
                 except IOError:
                     # now it is save to calculate and cache


### PR DESCRIPTION
To avoid the following warning

```
/home/malte/repos/schnetpack/src/schnetpack/transform/neighborlist.py:108:
FutureWarning: You are using `torch.load` with `weights_only=False` (the
current default value), which uses the default pickle module implicitly. It is
possible to construct malicious pickle data whi ch will execute arbitrary code
during unpickling (See
https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for
more details). In a future release, the default value for `weights_only` will
be flipped to `True`. This limits the functions that could be ex ecuted during
unpickling. Arbitrary objects will no longer be allowed to be loaded via this
mode unless they are explicitly allowlisted b y the user via
`torch.serialization.add_safe_globals`. We recommend you start setting
`weights_only=True` for any use case where you don' t have full control of the
loaded file. Please open an issue on GitHub for any issues related to this
experimental feature.
```