### PR TITLE
fix: use literal strings for strings containing invalid escape backslashes

### DIFF
--- a/src/schnetpack/nn/radial.py
+++ b/src/schnetpack/nn/radial.py
@@ -21,7 +21,7 @@ class GaussianRBF(nn.Module):
     def __init__(
         self, n_rbf: int, cutoff: float, start: float = 0.0, trainable: bool = False
     ):
-        """
+        r"""
         Args:
             n_rbf: total number of Gaussian functions, :math:`N_g`.
             cutoff: center of last Gaussian function, :math:`\mu_{N_g}`
@@ -54,7 +54,7 @@ class GaussianRBFCentered(nn.Module):
     def __init__(
         self, n_rbf: int, cutoff: float, start: float = 1.0, trainable: bool = False
     ):
-        """
+        r"""
         Args:
             n_rbf: total number of Gaussian functions, :math:`N_g`.
             cutoff: width of last Gaussian function, :math:`\mu_{N_g}`

--- a/src/schnetpack/units.py
+++ b/src/schnetpack/units.py
@@ -146,7 +146,7 @@ def _conversion_factor_internal(unit: str):
 def _parse_unit(unit, conversion_factor=_conversion_factor_ase):
     if type(unit) == str:
         # If a string is given, split into parts.
-        parts = re.split("(\W)", unit)
+        parts = re.split(r"(\W)", unit)
 
         conversion = 1.0
         divide = False


### PR DESCRIPTION
fixes https://github.com/atomistic-machine-learning/schnetpack/issues/750

It turns out that most of the occurrences mentioned in https://github.com/atomistic-machine-learning/schnetpack/issues/750 were already fixed, these are just some remaining ones.