### PR TITLE
Remove 'pytest-benchmark' from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
     "petname",
     "vesin",
     "pymatgen",
-    "pytest-benchmark",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Removed 'pytest-benchmark' from the main dependencies.