### PR TITLE
fix: previous url for qm9 is change to springnature.figshare from just ndownloader.figshare

### DIFF
--- a/src/schnetpack/datasets/qm9.py
+++ b/src/schnetpack/datasets/qm9.py
@@ -30,8 +30,18 @@ class QM9(AtomsDataModule):
 
     References:
 
-        .. [#qm9_1] https://springernature.figshare.com/ndownloader/files/3195404
+        .. [#qm9_1] https://ndownloader.figshare.com/files/3195404
     """
+
+    base_urls = [
+        "https://ndownloader.figshare.com/files/",
+        "https://springernature.figshare.com/ndownloader/files/",
+    ]
+    file_ids = {
+        "data": "3195389",
+        "atomrefs": "3195395",
+        "uncharacterized": "3195404",
+    }
 
     # properties
     A = "rotational_constant_A"
@@ -126,6 +136,18 @@ class QM9(AtomsDataModule):
 
         self.remove_uncharacterized = remove_uncharacterized
 
+    def _download_file(self, file_id: str, destination: str):
+        for base_url in self.base_urls:
+            url = f"{base_url}{file_id}"
+            try:
+                request.urlretrieve(url, destination)
+                return
+            except Exception:
+                logging.warning(f"Could not download from {url}, trying next source...")
+        raise AtomsDataModuleError(
+            f"Could not download file with id {file_id} from any source."
+        )
+
     def prepare_data(self):
         if not os.path.exists(self.datapath):
             property_unit_dict = {
@@ -178,9 +200,8 @@ class QM9(AtomsDataModule):
 
     def _download_uncharacterized(self, tmpdir):
         logging.info("Downloading list of uncharacterized molecules...")
-        at_url = "https://springernature.figshare.com/ndownloader/files/3195404"
         tmp_path = os.path.join(tmpdir, "uncharacterized.txt")
-        request.urlretrieve(at_url, tmp_path)
+        self._download_file(self.file_ids["uncharacterized"], tmp_path)
         logging.info("Done.")
 
         uncharacterized = []
@@ -192,9 +213,8 @@ class QM9(AtomsDataModule):
 
     def _download_atomrefs(self, tmpdir):
         logging.info("Downloading GDB-9 atom references...")
-        at_url = "https://springernature.figshare.com/ndownloader/files/3195395"
         tmp_path = os.path.join(tmpdir, "atomrefs.txt")
-        request.urlretrieve(at_url, tmp_path)
+        self._download_file(self.file_ids["atomrefs"], tmp_path)
         logging.info("Done.")
 
         props = [QM9.zpve, QM9.U0, QM9.U, QM9.H, QM9.G, QM9.Cv]
@@ -213,9 +233,7 @@ class QM9(AtomsDataModule):
         logging.info("Downloading GDB-9 data...")
         tar_path = os.path.join(tmpdir, "gdb9.tar.gz")
         raw_path = os.path.join(tmpdir, "gdb9_xyz")
-        url = "https://springernature.figshare.com/ndownloader/files/3195389"
-
-        request.urlretrieve(url, tar_path)
+        self._download_file(self.file_ids["data"], tar_path)
         logging.info("Done.")
 
         logging.info("Extracting files...")

--- a/src/schnetpack/datasets/qm9.py
+++ b/src/schnetpack/datasets/qm9.py
@@ -30,8 +30,7 @@ class QM9(AtomsDataModule):
 
     References:
 
-        .. [#qm9_1] https://ndownloader.figshare.com/files/3195404
-
+        .. [#qm9_1] https://springernature.figshare.com/ndownloader/files/3195404
     """
 
     # properties
@@ -179,7 +178,7 @@ class QM9(AtomsDataModule):
 
     def _download_uncharacterized(self, tmpdir):
         logging.info("Downloading list of uncharacterized molecules...")
-        at_url = "https://ndownloader.figshare.com/files/3195404"
+        at_url = "https://springernature.figshare.com/ndownloader/files/3195404"
         tmp_path = os.path.join(tmpdir, "uncharacterized.txt")
         request.urlretrieve(at_url, tmp_path)
         logging.info("Done.")
@@ -193,7 +192,7 @@ class QM9(AtomsDataModule):
 
     def _download_atomrefs(self, tmpdir):
         logging.info("Downloading GDB-9 atom references...")
-        at_url = "https://ndownloader.figshare.com/files/3195395"
+        at_url = "https://springernature.figshare.com/ndownloader/files/3195395"
         tmp_path = os.path.join(tmpdir, "atomrefs.txt")
         request.urlretrieve(at_url, tmp_path)
         logging.info("Done.")
@@ -214,7 +213,7 @@ class QM9(AtomsDataModule):
         logging.info("Downloading GDB-9 data...")
         tar_path = os.path.join(tmpdir, "gdb9.tar.gz")
         raw_path = os.path.join(tmpdir, "gdb9_xyz")
-        url = "https://ndownloader.figshare.com/files/3195389"
+        url = "https://springernature.figshare.com/ndownloader/files/3195389"
 
         request.urlretrieve(url, tar_path)
         logging.info("Done.")


### PR DESCRIPTION
Previous URL https://ndownloader.figshare.com/ changes into https://springernature.figshare.com/ndownloader/