### PR TITLE
Bug-Fix: Fallback to empty dict when `metrics=None` in `ModelOutput`

### DIFF
--- a/src/schnetpack/task.py
+++ b/src/schnetpack/task.py
@@ -46,9 +46,13 @@ class ModelOutput(nn.Module):
         self.target_property = target_property or name
         self.loss_fn = loss_fn
         self.loss_weight = loss_weight
-        self.train_metrics = nn.ModuleDict(metrics)
-        self.val_metrics = nn.ModuleDict({k: v.clone() for k, v in metrics.items()})
-        self.test_metrics = nn.ModuleDict({k: v.clone() for k, v in metrics.items()})
+        self.train_metrics = nn.ModuleDict(metrics or {})
+        self.val_metrics = nn.ModuleDict(
+            {k: v.clone() for k, v in self.train_metrics.items()}
+        )
+        self.test_metrics = nn.ModuleDict(
+            {k: v.clone() for k, v in self.train_metrics.items()}
+        )
         self.metrics = {
             "train": self.train_metrics,
             "val": self.val_metrics,


### PR DESCRIPTION
Right now the `ModelOutput` class fails to initiate when the `metrics` argument is unset even though it is labeled as optional.