### PR TITLE
Single-owner dataset statistics: pure stats functions, unified transform init, on-disk stats cache

### DIFF
--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -34,5 +34,7 @@ Statistics
     :template: classtemplate.rst
 
     calculate_stats
+    estimate_atomrefs
+    StatsAtomrefProvider
     NumberOfAtomsCriterion
     PropertyCriterion

--- a/docs/userguide/overview.rst
+++ b/docs/userguide/overview.rst
@@ -31,8 +31,11 @@ and calculation of neighbor lists.
 
 Furthermore, we support PyTorch Lightning datamodules through :class:`AtomsDataModule`,
 which combines :class:`ASEAtomsData` with code for preparation, setup and partitioning
-into train/validation/test splits. We provide specific implementations of
-:class:`AtomsDataModule` for several benchmark datasets.
+into train/validation/test splits. The datamodule also owns the training statistics
+(per-property mean/std and atom references): it exposes them via ``get_stats`` and
+``get_atomrefs``, initializes all transforms that require them, and persists computed
+values next to the split file so reruns read instead of recompute. We provide specific
+implementations of :class:`AtomsDataModule` for several benchmark datasets.
 
 
 Model

--- a/src/schnetpack/data/atoms.py
+++ b/src/schnetpack/data/atoms.py
@@ -165,11 +165,10 @@ class ASEAtomsData(torch.utils.data.Dataset):
             return self.test_transforms
         return self.transforms
 
-    def initialize_transforms(self, provider=None) -> None:
-        atomrefs = self.atomrefs  # read atomrefs once
+    def initialize_transforms(self, stats=None) -> None:
         for tf in self.get_split_transforms():
             if hasattr(tf, "initialize"):
-                tf.initialize(provider=provider, atomrefs=atomrefs)
+                tf.initialize(stats)
 
     def _apply_transforms(
         self, props: Dict[str, torch.Tensor]

--- a/src/schnetpack/data/datamodule.py
+++ b/src/schnetpack/data/datamodule.py
@@ -9,7 +9,7 @@ from torch.utils.data import BatchSampler
 
 from schnetpack.data.atoms import ASEAtomsData
 from schnetpack.data.provider import StatsAtomrefProvider, train_partition_fingerprint
-from schnetpack.data.splitting import RandomSplit, SplittingStrategy
+from schnetpack.data.splitting import SPLITTING_LOCK, RandomSplit, SplittingStrategy
 from schnetpack.data.loader import AtomsLoader
 
 __all__ = ["AtomsDataModule"]
@@ -231,7 +231,7 @@ class AtomsDataModule(pl.LightningDataModule):
         # Serialize split creation with an inter-process lock, so concurrent
         # DDP ranks / jobs cannot race on writing split.npz and end up with
         # different partitions per rank.
-        lock = fasteners.InterProcessLock("splitting.lock")
+        lock = fasteners.InterProcessLock(SPLITTING_LOCK)
 
         with lock:
             total_size = len(self.dataset)

--- a/src/schnetpack/data/datamodule.py
+++ b/src/schnetpack/data/datamodule.py
@@ -8,7 +8,7 @@ import torch
 from torch.utils.data import BatchSampler
 
 from schnetpack.data.atoms import ASEAtomsData
-from schnetpack.data.provider import StatsAtomrefProvider
+from schnetpack.data.provider import StatsAtomrefProvider, train_partition_fingerprint
 from schnetpack.data.splitting import RandomSplit, SplittingStrategy
 from schnetpack.data.loader import AtomsLoader
 
@@ -116,6 +116,7 @@ class AtomsDataModule(pl.LightningDataModule):
         self.train_idx = None
         self.val_idx = None
         self.test_idx = None
+        self.train_fingerprint: Optional[str] = None
 
         self._train_dataset = None
         self._val_dataset = None
@@ -157,6 +158,12 @@ class AtomsDataModule(pl.LightningDataModule):
 
         if self.train_idx is None:
             self._load_partitions()
+
+        # Statistics are a pure function of (dataset, train partition); the
+        # fingerprint identifies that partition, e.g. for persisted stats.
+        self.train_fingerprint = train_partition_fingerprint(
+            len(self.dataset), self.train_idx
+        )
 
         # The split label activates the per-split transform selection of
         # ASEAtomsData for anyone touching the subsets directly.

--- a/src/schnetpack/data/datamodule.py
+++ b/src/schnetpack/data/datamodule.py
@@ -14,6 +14,10 @@ from schnetpack.data.loader import AtomsLoader
 
 __all__ = ["AtomsDataModule"]
 
+# Default for stats_file: derive the path from split_file. A sentinel (not
+# None) because None means "persistence off".
+_DERIVE_STATS_FILE = "<derive from split_file>"
+
 
 class AtomsDataModule(pl.LightningDataModule):
     """
@@ -53,6 +57,7 @@ class AtomsDataModule(pl.LightningDataModule):
         num_val: Union[int, float],
         num_test: Optional[Union[int, float]] = None,
         split_file: Optional[str] = "split.npz",
+        stats_file: Optional[str] = _DERIVE_STATS_FILE,
         splitting: Optional[SplittingStrategy] = None,
         num_workers: int = 0,
         val_batch_size: Optional[int] = None,
@@ -71,6 +76,11 @@ class AtomsDataModule(pl.LightningDataModule):
             num_val: number of validation examples (absolute or relative)
             num_test: number of test examples (absolute or relative)
             split_file: path to npz file with data partitions
+            stats_file: path to the npz file persisting training statistics
+                and estimated atomrefs, keyed by the train-partition
+                fingerprint. By default derived from split_file
+                (<split>_stats.npz next to it). Set to None to disable
+                persistence; reruns then recompute statistics.
             splitting: Method to generate train/validation/test partitions
                     (default: RandomSplit)
             num_workers: Number of data loader workers
@@ -109,6 +119,13 @@ class AtomsDataModule(pl.LightningDataModule):
         self.num_val = num_val
         self.num_test = num_test
         self.split_file = split_file
+        if stats_file == _DERIVE_STATS_FILE:
+            stats_file = (
+                os.path.splitext(split_file)[0] + "_stats.npz"
+                if split_file is not None
+                else None
+            )
+        self.stats_file = stats_file
         self.splitting = splitting or RandomSplit()
         self.num_workers = num_workers
         self._pin_memory = pin_memory
@@ -171,7 +188,12 @@ class AtomsDataModule(pl.LightningDataModule):
         self._val_dataset = self.dataset.subset(self.val_idx, split="val")
         self._test_dataset = self.dataset.subset(self.test_idx, split="test")
 
-        self.provider = self._provider_cls(self.dataset, self.train_idx)
+        self.provider = self._provider_cls(
+            self.dataset,
+            self.train_idx,
+            stats_file=self.stats_file,
+            fingerprint=self.train_fingerprint,
+        )
 
         self._train_dataset.initialize_transforms(self.provider)
         self._val_dataset.initialize_transforms(self.provider)

--- a/src/schnetpack/data/datamodule.py
+++ b/src/schnetpack/data/datamodule.py
@@ -166,9 +166,9 @@ class AtomsDataModule(pl.LightningDataModule):
 
         self.provider = self._provider_cls(self.dataset, self.train_idx)
 
-        self._train_dataset.initialize_transforms(provider=self.provider)
-        self._val_dataset.initialize_transforms(provider=self.provider)
-        self._test_dataset.initialize_transforms(provider=self.provider)
+        self._train_dataset.initialize_transforms(self.provider)
+        self._val_dataset.initialize_transforms(self.provider)
+        self._test_dataset.initialize_transforms(self.provider)
 
     def teardown(self, stage: Optional[str] = None) -> None:
         # Transforms with external resources (e.g. cached neighbor lists)

--- a/src/schnetpack/data/datamodule.py
+++ b/src/schnetpack/data/datamodule.py
@@ -179,8 +179,9 @@ class AtomsDataModule(pl.LightningDataModule):
             for t in ds.get_split_transforms():
                 t.teardown()
 
-    # Model postprocessors (e.g. AddOffsets) are initialized through
-    # `Transform.datamodule(dm)` and must read from the *same* cached provider
+    # The datamodule itself satisfies the stats-source protocol: model
+    # postprocessors (e.g. AddOffsets) are initialized late via
+    # `initialize(datamodule)` and must read from the *same* cached provider
     # as the data-pipeline transforms — otherwise they would recompute
     # statistics on already-transformed data and end up with wrong offsets.
     def get_stats(

--- a/src/schnetpack/data/datamodule.py
+++ b/src/schnetpack/data/datamodule.py
@@ -83,8 +83,9 @@ class AtomsDataModule(pl.LightningDataModule):
             train_sampler_args: dict of train_sampler keyword arguments.
             pin_memory: If true, pin memory of loaded data to GPU. Default: Will be
                     set to true, when GPUs are used.
-            provider: stats provider class built from the train split during
-                setup(). If None, use StatsAtomrefProvider.
+            provider: stats provider class, constructed during setup() from
+                the base dataset and the train index list. If None, use
+                StatsAtomrefProvider.
         """
         # Unknown kwargs other than the legacy arguments are tolerated
         # silently, because hydra data configs use top-level keys as
@@ -163,7 +164,7 @@ class AtomsDataModule(pl.LightningDataModule):
         self._val_dataset = self.dataset.subset(self.val_idx, split="val")
         self._test_dataset = self.dataset.subset(self.test_idx, split="test")
 
-        self.provider = self._provider_cls(self._train_dataset)
+        self.provider = self._provider_cls(self.dataset, self.train_idx)
 
         self._train_dataset.initialize_transforms(provider=self.provider)
         self._val_dataset.initialize_transforms(provider=self.provider)

--- a/src/schnetpack/data/datamodule.py
+++ b/src/schnetpack/data/datamodule.py
@@ -191,11 +191,11 @@ class AtomsDataModule(pl.LightningDataModule):
         return self.provider.get_stats(property, divide_by_atoms, remove_atomref)
 
     def get_atomrefs(
-        self, property: str, is_extensive: bool
+        self, property: str, is_extensive: bool, estimate: bool = True
     ) -> Dict[str, torch.Tensor]:
         if self.provider is None:
             raise RuntimeError("Call setup() before accessing atomrefs.")
-        return self.provider.get_atomrefs(property, is_extensive)
+        return self.provider.get_atomrefs(property, is_extensive, estimate)
 
     def _load_partitions(self) -> None:
         # Serialize split creation with an inter-process lock, so concurrent

--- a/src/schnetpack/data/provider.py
+++ b/src/schnetpack/data/provider.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Dict, List, Optional, Tuple
 
 import torch
@@ -7,7 +9,22 @@ import torch
 from schnetpack.data.atoms import ASEAtomsData
 from schnetpack.data.stats import calculate_stats, estimate_atomrefs
 
-__all__ = ["StatsAtomrefProvider"]
+__all__ = ["StatsAtomrefProvider", "train_partition_fingerprint"]
+
+
+def train_partition_fingerprint(dataset_length: int, train_idx: List[int]) -> str:
+    """
+    Short deterministic fingerprint of a train partition.
+
+    Statistics are a pure function of the dataset and the train partition;
+    the fingerprint keys persisted statistics to that partition. The index
+    list is sorted first — permutations of the same partition yield the same
+    statistics.
+    """
+    payload = json.dumps(
+        [int(dataset_length), sorted(int(i) for i in train_idx)]
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()[:16]
 
 
 class StatsAtomrefProvider:

--- a/src/schnetpack/data/provider.py
+++ b/src/schnetpack/data/provider.py
@@ -57,6 +57,11 @@ class StatsAtomrefProvider:
         self.dataset = dataset
         self.train_idx = list(train_idx)
         self.train_atomrefs = getattr(dataset, "atomrefs", None)
+        # np.savez appends ".npz" to paths missing it; normalize up front so
+        # the read path (which checks the verbatim path) finds what was
+        # written.
+        if stats_file is not None and not stats_file.endswith(".npz"):
+            stats_file += ".npz"
         self.stats_file = stats_file
         self.fingerprint = fingerprint or train_partition_fingerprint(
             len(dataset), self.train_idx

--- a/src/schnetpack/data/provider.py
+++ b/src/schnetpack/data/provider.py
@@ -51,11 +51,17 @@ class StatsAtomrefProvider:
         return stats
 
     def get_atomrefs(
-        self, property: str, is_extensive: bool
+        self, property: str, is_extensive: bool, estimate: bool = True
     ) -> Dict[str, torch.Tensor]:
         # 1) If dataset already has atomrefs for this property, use them directly
         if self.train_atomrefs is not None and property in self.train_atomrefs:
             return {property: self.train_atomrefs[property]}
+
+        if not estimate:
+            raise RuntimeError(
+                f"The dataset provides no atomrefs for property '{property}' "
+                "and atomref estimation is disabled."
+            )
 
         # 2) Otherwise estimate and cache
         key = (property, is_extensive)

--- a/src/schnetpack/data/provider.py
+++ b/src/schnetpack/data/provider.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import copy
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 
@@ -13,22 +12,19 @@ __all__ = ["StatsAtomrefProvider"]
 
 class StatsAtomrefProvider:
     """
-    Compute and cache statistics and atom references from the training dataset.
+    Compute and cache statistics and atom references of the training data.
+
+    Statistics are a pure function of the base dataset and the train index
+    list: the stats functions build their own raw (transform-free) view from
+    the explicit indices, so the provider may be queried at any time — even
+    after the dataset has its transforms attached — without ever computing
+    on transformed data.
     """
 
-    def __init__(self, train_dataset: ASEAtomsData) -> None:
-        self.train_dataset = train_dataset
-        self.train_atomrefs = getattr(train_dataset, "atomrefs", None)
-
-        # Statistics must always be computed on the *raw* training data. The
-        # provider may be queried lazily (e.g. by AddOffsets during model
-        # setup) after the train dataset already has its transforms attached —
-        # computing stats through RemoveOffsets etc. would silently yield
-        # wrong means. Use a shallow copy with transforms stripped, so timing
-        # no longer matters.
-        self._raw_train_dataset = copy.copy(train_dataset)
-        self._raw_train_dataset.transforms = []
-        self._raw_train_dataset.split = None
+    def __init__(self, dataset: ASEAtomsData, train_idx: List[int]) -> None:
+        self.dataset = dataset
+        self.train_idx = list(train_idx)
+        self.train_atomrefs = getattr(dataset, "atomrefs", None)
 
         self._stats_cache: Dict[
             Tuple[str, bool, bool], Tuple[torch.Tensor, torch.Tensor]
@@ -45,9 +41,10 @@ class StatsAtomrefProvider:
         atomref = self.train_atomrefs if remove_atomref else None
 
         stats = calculate_stats(
-            self._raw_train_dataset,
+            self.dataset,
             divide_by_atoms={property: divide_by_atoms},
             atomref=atomref,
+            indices=self.train_idx,
         )[property]
 
         self._stats_cache[key] = stats
@@ -66,8 +63,9 @@ class StatsAtomrefProvider:
             return {property: self._atomref_cache[key]}
 
         atomref = estimate_atomrefs(
-            self._raw_train_dataset,
+            self.dataset,
             is_extensive={property: is_extensive},
+            indices=self.train_idx,
         )[property]
 
         self._atomref_cache[key] = atomref

--- a/src/schnetpack/data/provider.py
+++ b/src/schnetpack/data/provider.py
@@ -94,9 +94,7 @@ class StatsAtomrefProvider:
         with fasteners.InterProcessLock(_SPLITTING_LOCK):
             entries = self._load_valid_entries()
             entries[entry_key] = value
-            np.savez(
-                self.stats_file, fingerprint=np.array(self.fingerprint), **entries
-            )
+            np.savez(self.stats_file, fingerprint=np.array(self.fingerprint), **entries)
 
     # ---------- queries ----------
 

--- a/src/schnetpack/data/provider.py
+++ b/src/schnetpack/data/provider.py
@@ -143,10 +143,18 @@ class StatsAtomrefProvider:
                 "and atomref estimation is disabled."
             )
 
-        # 2) Otherwise estimate and cache
+        # 2) Otherwise estimate and cache. Only estimated atomrefs are
+        # persisted — dataset-provided ones already live in the DB metadata.
         key = (property, is_extensive)
         if key in self._atomref_cache:
             return {property: self._atomref_cache[key]}
+
+        entry_key = "atomrefs:" + json.dumps(list(key))
+        stored = self._read_entry(entry_key)
+        if stored is not None:
+            atomref = torch.tensor(stored)
+            self._atomref_cache[key] = atomref
+            return {property: atomref}
 
         atomref = estimate_atomrefs(
             self.dataset,
@@ -155,4 +163,5 @@ class StatsAtomrefProvider:
         )[property]
 
         self._atomref_cache[key] = atomref
+        self._write_entry(entry_key, atomref.detach().cpu().numpy())
         return {property: atomref}

--- a/src/schnetpack/data/provider.py
+++ b/src/schnetpack/data/provider.py
@@ -3,21 +3,17 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import fasteners
 import numpy as np
 import torch
 
 from schnetpack.data.atoms import ASEAtomsData
+from schnetpack.data.splitting import SPLITTING_LOCK
 from schnetpack.data.stats import calculate_stats, estimate_atomrefs
 
 __all__ = ["StatsAtomrefProvider", "train_partition_fingerprint"]
-
-# Same inter-process lock as split creation: statistics have the same lineage
-# as the split, and sharing the lock means concurrent DDP ranks compute each
-# entry at most once.
-_SPLITTING_LOCK = "splitting.lock"
 
 
 def train_partition_fingerprint(dataset_length: int, train_idx: List[int]) -> str:
@@ -82,19 +78,27 @@ class StatsAtomrefProvider:
             return {}
         return entries
 
-    def _read_entry(self, entry_key: str) -> Optional[np.ndarray]:
-        if self.stats_file is None:
-            return None
-        with fasteners.InterProcessLock(_SPLITTING_LOCK):
-            return self._load_valid_entries().get(entry_key)
+    def _read_or_compute(
+        self, entry_key: str, compute: Callable[[], np.ndarray]
+    ) -> np.ndarray:
+        """
+        Return the persisted entry, or compute and persist it.
 
-    def _write_entry(self, entry_key: str, value: np.ndarray) -> None:
+        The lock — the same one that serializes split creation — is held
+        across the whole miss → compute → write cycle, so concurrent ranks
+        compute each entry at most once.
+        """
         if self.stats_file is None:
-            return
-        with fasteners.InterProcessLock(_SPLITTING_LOCK):
+            return compute()
+        with fasteners.InterProcessLock(SPLITTING_LOCK):
             entries = self._load_valid_entries()
+            stored = entries.get(entry_key)
+            if stored is not None:
+                return stored
+            value = compute()
             entries[entry_key] = value
             np.savez(self.stats_file, fingerprint=np.array(self.fingerprint), **entries)
+            return value
 
     # ---------- queries ----------
 
@@ -105,27 +109,20 @@ class StatsAtomrefProvider:
         if key in self._stats_cache:
             return self._stats_cache[key]
 
-        entry_key = "stats:" + json.dumps(list(key))
-        stored = self._read_entry(entry_key)
-        if stored is not None:
-            stats = (torch.tensor(stored[0]), torch.tensor(stored[1]))
-            self._stats_cache[key] = stats
-            return stats
+        def compute() -> np.ndarray:
+            atomref = self.train_atomrefs if remove_atomref else None
+            mean, std = calculate_stats(
+                self.dataset,
+                divide_by_atoms={property: divide_by_atoms},
+                atomref=atomref,
+                indices=self.train_idx,
+            )[property]
+            return np.array([mean.item(), std.item()], dtype=np.float64)
 
-        atomref = self.train_atomrefs if remove_atomref else None
-
-        stats = calculate_stats(
-            self.dataset,
-            divide_by_atoms={property: divide_by_atoms},
-            atomref=atomref,
-            indices=self.train_idx,
-        )[property]
+        stored = self._read_or_compute("stats:" + json.dumps(list(key)), compute)
+        stats = (torch.tensor(stored[0]), torch.tensor(stored[1]))
 
         self._stats_cache[key] = stats
-        mean, std = stats
-        self._write_entry(
-            entry_key, np.array([mean.item(), std.item()], dtype=np.float64)
-        )
         return stats
 
     def get_atomrefs(
@@ -147,19 +144,20 @@ class StatsAtomrefProvider:
         if key in self._atomref_cache:
             return {property: self._atomref_cache[key]}
 
-        entry_key = "atomrefs:" + json.dumps(list(key))
-        stored = self._read_entry(entry_key)
-        if stored is not None:
-            atomref = torch.tensor(stored)
-            self._atomref_cache[key] = atomref
-            return {property: atomref}
+        def compute() -> np.ndarray:
+            return (
+                estimate_atomrefs(
+                    self.dataset,
+                    is_extensive={property: is_extensive},
+                    indices=self.train_idx,
+                )[property]
+                .detach()
+                .cpu()
+                .numpy()
+            )
 
-        atomref = estimate_atomrefs(
-            self.dataset,
-            is_extensive={property: is_extensive},
-            indices=self.train_idx,
-        )[property]
+        stored = self._read_or_compute("atomrefs:" + json.dumps(list(key)), compute)
+        atomref = torch.tensor(stored)
 
         self._atomref_cache[key] = atomref
-        self._write_entry(entry_key, atomref.detach().cpu().numpy())
         return {property: atomref}

--- a/src/schnetpack/data/provider.py
+++ b/src/schnetpack/data/provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import zipfile
 from typing import Callable, Dict, List, Optional, Tuple
 
 import fasteners
@@ -69,11 +70,16 @@ class StatsAtomrefProvider:
     # ---------- disk persistence ----------
 
     def _load_valid_entries(self) -> Dict[str, np.ndarray]:
-        """Stored entries, or {} if absent or written for another partition."""
+        """Stored entries, or {} if absent, unreadable, or another partition's."""
         if not os.path.exists(self.stats_file):
             return {}
-        with np.load(self.stats_file) as data:
-            entries = dict(data)
+        try:
+            with np.load(self.stats_file) as data:
+                entries = dict(data)
+        except (OSError, ValueError, EOFError, zipfile.BadZipFile):
+            # An unreadable cache file (e.g. left by a crash mid-write) must
+            # never break setup — recompute and overwrite it instead.
+            return {}
         if str(entries.pop("fingerprint", None)) != self.fingerprint:
             return {}
         return entries

--- a/src/schnetpack/data/provider.py
+++ b/src/schnetpack/data/provider.py
@@ -2,14 +2,22 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from typing import Dict, List, Optional, Tuple
 
+import fasteners
+import numpy as np
 import torch
 
 from schnetpack.data.atoms import ASEAtomsData
 from schnetpack.data.stats import calculate_stats, estimate_atomrefs
 
 __all__ = ["StatsAtomrefProvider", "train_partition_fingerprint"]
+
+# Same inter-process lock as split creation: statistics have the same lineage
+# as the split, and sharing the lock means concurrent DDP ranks compute each
+# entry at most once.
+_SPLITTING_LOCK = "splitting.lock"
 
 
 def train_partition_fingerprint(dataset_length: int, train_idx: List[int]) -> str:
@@ -36,17 +44,61 @@ class StatsAtomrefProvider:
     the explicit indices, so the provider may be queried at any time — even
     after the dataset has its transforms attached — without ever computing
     on transformed data.
+
+    With a stats file set, computed values are persisted to disk, keyed by
+    the train-partition fingerprint: reruns and additional DDP ranks read
+    instead of recompute. A None stats file disables persistence.
     """
 
-    def __init__(self, dataset: ASEAtomsData, train_idx: List[int]) -> None:
+    def __init__(
+        self,
+        dataset: ASEAtomsData,
+        train_idx: List[int],
+        stats_file: Optional[str] = None,
+        fingerprint: Optional[str] = None,
+    ) -> None:
         self.dataset = dataset
         self.train_idx = list(train_idx)
         self.train_atomrefs = getattr(dataset, "atomrefs", None)
+        self.stats_file = stats_file
+        self.fingerprint = fingerprint or train_partition_fingerprint(
+            len(dataset), self.train_idx
+        )
 
         self._stats_cache: Dict[
             Tuple[str, bool, bool], Tuple[torch.Tensor, torch.Tensor]
         ] = {}
         self._atomref_cache: Dict[Tuple[str, bool], torch.Tensor] = {}
+
+    # ---------- disk persistence ----------
+
+    def _load_valid_entries(self) -> Dict[str, np.ndarray]:
+        """Stored entries, or {} if absent or written for another partition."""
+        if not os.path.exists(self.stats_file):
+            return {}
+        with np.load(self.stats_file) as data:
+            entries = dict(data)
+        if str(entries.pop("fingerprint", None)) != self.fingerprint:
+            return {}
+        return entries
+
+    def _read_entry(self, entry_key: str) -> Optional[np.ndarray]:
+        if self.stats_file is None:
+            return None
+        with fasteners.InterProcessLock(_SPLITTING_LOCK):
+            return self._load_valid_entries().get(entry_key)
+
+    def _write_entry(self, entry_key: str, value: np.ndarray) -> None:
+        if self.stats_file is None:
+            return
+        with fasteners.InterProcessLock(_SPLITTING_LOCK):
+            entries = self._load_valid_entries()
+            entries[entry_key] = value
+            np.savez(
+                self.stats_file, fingerprint=np.array(self.fingerprint), **entries
+            )
+
+    # ---------- queries ----------
 
     def get_stats(
         self, property: str, divide_by_atoms: bool, remove_atomref: bool
@@ -54,6 +106,13 @@ class StatsAtomrefProvider:
         key = (property, divide_by_atoms, remove_atomref)
         if key in self._stats_cache:
             return self._stats_cache[key]
+
+        entry_key = "stats:" + json.dumps(list(key))
+        stored = self._read_entry(entry_key)
+        if stored is not None:
+            stats = (torch.tensor(stored[0]), torch.tensor(stored[1]))
+            self._stats_cache[key] = stats
+            return stats
 
         atomref = self.train_atomrefs if remove_atomref else None
 
@@ -65,6 +124,10 @@ class StatsAtomrefProvider:
         )[property]
 
         self._stats_cache[key] = stats
+        mean, std = stats
+        self._write_entry(
+            entry_key, np.array([mean.item(), std.item()], dtype=np.float64)
+        )
         return stats
 
     def get_atomrefs(

--- a/src/schnetpack/data/splitting.py
+++ b/src/schnetpack/data/splitting.py
@@ -5,6 +5,11 @@ import numpy as np
 
 __all__ = ["SplittingStrategy", "RandomSplit", "SubsamplePartitions", "GroupSplit"]
 
+# Inter-process lock file serializing split creation and the persisted-stats
+# read-modify-write. One shared constant: stats writes must take the *same*
+# lock as split creation.
+SPLITTING_LOCK = "splitting.lock"
+
 
 def absolute_split_sizes(dsize: int, split_sizes: List[int]) -> List[int]:
     """

--- a/src/schnetpack/data/stats.py
+++ b/src/schnetpack/data/stats.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, Optional, Any
+from typing import Dict, List, Tuple, Optional, Any
 
 import torch
 from tqdm import tqdm
@@ -8,6 +8,21 @@ from schnetpack.data.atoms import ASEAtomsData
 from schnetpack.data.loader import AtomsLoader
 
 __all__ = ["calculate_stats", "estimate_atomrefs"]
+
+
+def _raw_view(dataset: ASEAtomsData, indices: Optional[List[int]]) -> ASEAtomsData:
+    """
+    Statistics must always be computed on raw data. Build an index-restricted
+    view of the dataset with no transforms and no split label, so that
+    whatever view the caller holds (transformed, split-labeled) can never leak
+    into statistics computation.
+    """
+    if indices is None:
+        return dataset
+    view = dataset.subset(list(indices))
+    view.transforms = []
+    view.split = None
+    return view
 
 
 def calculate_stats(
@@ -20,6 +35,7 @@ def calculate_stats(
     # one-off pass anyway.
     num_workers: int = 0,
     loader_kwargs: Optional[Dict[str, Any]] = None,
+    indices: Optional[List[int]] = None,
 ) -> Dict[str, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Use the incremental Welford algorithm described in [h1]_ to accumulate
@@ -36,11 +52,15 @@ def calculate_stats(
         atomref: Optional single-atom reference values to subtract before computing statistics.
         batch_size: Batch size used for the temporary data loader.
         num_workers: Number of workers used by the data loader.
+        indices: Optional indices into `dataset` to restrict the computation
+            to. When given, statistics are computed on a raw view of these
+            entries — any transforms or split label on `dataset` are ignored.
 
     Returns:
         Mapping from property name to `(mean, std)` tensors.
     """
     loader_kwargs = loader_kwargs or {}
+    dataset = _raw_view(dataset, indices)
 
     dataloader = AtomsLoader(
         dataset,
@@ -107,6 +127,7 @@ def estimate_atomrefs(
     # num_workers=0: see calculate_stats — safe, deterministic defaults.
     num_workers: int = 0,
     loader_kwargs: Optional[Dict[str, Any]] = None,
+    indices: Optional[List[int]] = None,
 ) -> Dict[str, torch.Tensor]:
     """
     Uses linear regression to estimate the elementwise biases (atomrefs).
@@ -118,11 +139,15 @@ def estimate_atomrefs(
         z_max: Maximum atomic number used to size the atomref tensors.
         batch_size: Batch size used for the temporary data loader.
         num_workers: Number of workers used by the data loader.
+        indices: Optional indices into `dataset` to restrict the computation
+            to. When given, atomrefs are estimated on a raw view of these
+            entries — any transforms or split label on `dataset` are ignored.
 
     Returns:
         Mapping from property name to estimated atom reference tensor.
     """
     loader_kwargs = loader_kwargs or {}
+    dataset = _raw_view(dataset, indices)
 
     dataloader = AtomsLoader(
         dataset,

--- a/src/schnetpack/model/base.py
+++ b/src/schnetpack/model/base.py
@@ -68,8 +68,9 @@ class AtomisticModel(nn.Module):
         """
         Args:
             postprocessors: Post-processing transforms that may be
-                initialized using the `datamodule`, but are not
-                applied during training.
+                initialized with training statistics (via
+                `initialize_transforms`), but are not applied during
+                training.
             input_dtype: The dtype of real inputs as string.
             do_postprocessing: If true, post-processing is activated.
         """
@@ -158,8 +159,9 @@ class NeuralNetworkPotential(AtomisticModel):
                 modify input or add additional tensors for response properties.
             output_modules: Modules that predict output properties from the
                 representation.
-            postprocessors: Post-processing transforms that may be initialized using the
-                `datamodule`, but are not applied during training.
+            postprocessors: Post-processing transforms that may be initialized with
+                training statistics (via `initialize_transforms`), but are not
+                applied during training.
             input_dtype_str: The dtype of real inputs.
             do_postprocessing: If true, post-processing is activated.
         """

--- a/src/schnetpack/model/base.py
+++ b/src/schnetpack/model/base.py
@@ -111,9 +111,13 @@ class AtomisticModel(nn.Module):
         return inputs
 
     def initialize_transforms(self, datamodule):
+        # The datamodule satisfies the stats-source protocol
+        # (get_stats/get_atomrefs) and shares one cached provider with the
+        # data-pipeline transforms, so late initialization here yields the
+        # same raw-training-data statistics.
         for module in self.modules():
             if isinstance(module, Transform):
-                module.datamodule(datamodule)
+                module.initialize(datamodule)
 
     def postprocess(self, inputs: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
         if self.do_postprocessing:

--- a/src/schnetpack/transform/atomistic.py
+++ b/src/schnetpack/transform/atomistic.py
@@ -117,23 +117,19 @@ class RemoveOffsets(Transform):
             property_mean = property_mean or torch.zeros((1,))
             self.register_buffer("mean", property_mean)
 
-    def initialize(self, provider, atomrefs=None, **kwargs) -> None:
+    def initialize(self, stats) -> None:
         """
-        Initialize mean and/or atomref using a StatsAtomrefProvider.
+        Initialize mean and/or atomrefs from a stats source (any object with
+        ``get_stats``/``get_atomrefs``, e.g. the datamodule or its provider).
         """
         if self.remove_atomrefs and not self._atomrefs_initialized:
-            if self.estimate_atomref:
-                atrefs = provider.get_atomrefs(self._property, self.is_extensive)
-            else:
-                if atomrefs is None:
-                    raise RuntimeError(
-                        "RemoveOffsets requires dataset atomrefs when estimate_atomref=False."
-                    )
-                atrefs = atomrefs
+            atrefs = stats.get_atomrefs(
+                self._property, self.is_extensive, estimate=self.estimate_atomref
+            )
             self.atomref = atrefs[self._property].detach()
 
         if self.remove_mean and not self._mean_initialized:
-            mean, _std = provider.get_stats(
+            mean, _std = stats.get_stats(
                 self._property, self.is_extensive, self.remove_atomrefs
             )
             self.mean = mean.detach()
@@ -226,12 +222,12 @@ class ScaleProperty(Transform):
         scale = scale or torch.ones((1,))
         self.register_buffer("scale", scale)
 
-    def initialize(self, provider, atomrefs=None) -> None:
+    def initialize(self, stats) -> None:
         """
         Initialize scaling using training statistics.
         """
         if not self._initialized:
-            mean, std = provider.get_stats(self._target_key, True, False)
+            mean, std = stats.get_stats(self._target_key, True, False)
             scale = mean if self._scale_by_mean else std
             self.scale = torch.abs(scale).detach()
 
@@ -313,23 +309,19 @@ class AddOffsets(Transform):
         self.register_buffer("atomref", atomrefs)
         self.register_buffer("mean", property_mean)
 
-    def initialize(self, provider, atomrefs=None) -> None:
+    def initialize(self, stats) -> None:
         """
-        Initialize mean and/or atomref using a StatsAtomrefProvider.
+        Initialize mean and/or atomrefs from a stats source (any object with
+        ``get_stats``/``get_atomrefs``, e.g. the datamodule or its provider).
         """
         if self.add_atomrefs and not self._atomrefs_initialized:
-            if self.estimate_atomref:
-                atrefs = provider.get_atomrefs(self._property, self.is_extensive)
-            else:
-                if atomrefs is None:
-                    raise RuntimeError(
-                        "AddOffsets requires dataset atomrefs when estimate_atomref=False."
-                    )
-                atrefs = atomrefs
+            atrefs = stats.get_atomrefs(
+                self._property, self.is_extensive, estimate=self.estimate_atomref
+            )
             self.atomref = atrefs[self._property].detach()
 
         if self.add_mean and not self._mean_initialized:
-            mean, _std = provider.get_stats(
+            mean, _std = stats.get_stats(
                 self._property, self.is_extensive, self.add_atomrefs
             )
             self.mean = mean.detach()

--- a/src/schnetpack/transform/atomistic.py
+++ b/src/schnetpack/transform/atomistic.py
@@ -156,10 +156,11 @@ class RemoveOffsets(Transform):
 
 class ScaleProperty(Transform):
     """
-    Scale an entry of the input or results dioctionary.
+    Scale an entry of the input or results dictionary.
 
-    The `scale` can be automatically obtained from the AtomsDataModule,
-    when it is used. Otherwise, it has to be provided in the init manually.
+    The `scale` can be obtained automatically from training statistics via
+    `initialize(stats)`. Otherwise, it has to be provided in the init
+    manually.
 
     """
 

--- a/src/schnetpack/transform/atomistic.py
+++ b/src/schnetpack/transform/atomistic.py
@@ -134,29 +134,6 @@ class RemoveOffsets(Transform):
             )
             self.mean = mean.detach()
 
-    def datamodule(self, _datamodule):
-        """
-        Hook called with the AtomsDataModule when using the PyTorch Lightning
-        integration (see AtomisticModel.initialize_transforms).
-        """
-        # Statistics must come from the datamodule's cached provider:
-        # recomputing them here would run on data whose transforms have
-        # already removed the offsets.
-        if self.remove_atomrefs and not self._atomrefs_initialized:
-            if self.estimate_atomref:
-                atrefs = _datamodule.get_atomrefs(
-                    property=self._property, is_extensive=self.is_extensive
-                )
-            else:
-                atrefs = _datamodule.train_dataset.atomrefs
-            self.atomref = atrefs[self._property].detach()
-
-        if self.remove_mean and not self._mean_initialized:
-            stats = _datamodule.get_stats(
-                self._property, self.is_extensive, self.remove_atomrefs
-            )
-            self.mean = stats[0].detach()
-
     def forward(
         self,
         inputs: Dict[str, torch.Tensor],
@@ -229,16 +206,6 @@ class ScaleProperty(Transform):
         if not self._initialized:
             mean, std = stats.get_stats(self._target_key, True, False)
             scale = mean if self._scale_by_mean else std
-            self.scale = torch.abs(scale).detach()
-
-    def datamodule(self, _datamodule):
-        """
-        Hook called with the AtomsDataModule when using the PyTorch Lightning
-        integration.
-        """
-        if not self._initialized:
-            stats = _datamodule.get_stats(self._target_key, True, False)
-            scale = stats[0] if self._scale_by_mean else stats[1]
             self.scale = torch.abs(scale).detach()
 
     def forward(
@@ -325,29 +292,6 @@ class AddOffsets(Transform):
                 self._property, self.is_extensive, self.add_atomrefs
             )
             self.mean = mean.detach()
-
-    def datamodule(self, _datamodule):
-        """
-        Hook called with the AtomsDataModule when using the PyTorch Lightning
-        integration (see AtomisticModel.initialize_transforms).
-        """
-        # Statistics must come from the datamodule's cached provider:
-        # recomputing them here would run on data whose transforms have
-        # already removed the offsets, yielding a near-zero mean.
-        if self.add_atomrefs and not self._atomrefs_initialized:
-            if self.estimate_atomref:
-                atrefs = _datamodule.get_atomrefs(
-                    property=self._property, is_extensive=self.is_extensive
-                )
-            else:
-                atrefs = _datamodule.train_dataset.atomrefs
-            self.atomref = atrefs[self._property].detach()
-
-        if self.add_mean and not self._mean_initialized:
-            stats = _datamodule.get_stats(
-                self._property, self.is_extensive, self.add_atomrefs
-            )
-            self.mean = stats[0].detach()
 
     def forward(
         self,

--- a/src/schnetpack/transform/base.py
+++ b/src/schnetpack/transform/base.py
@@ -18,8 +18,6 @@ class TransformException(Exception):
 class Transform(nn.Module):
     """
     Base class for all transforms.
-    The base class ensures that the reference to the data and datamodule attributes are
-    initialized.
     Transforms can be used as pre- or post-processing layers.
     They can also be used for other parts of a model, that need to be
     initialized based on data.
@@ -28,18 +26,12 @@ class Transform(nn.Module):
     to single examples, while postprocessors operate on batches. All transforms should
     return a modified `inputs` dictionary.
 
+    Transforms that require training statistics override ``initialize``, the
+    single initialization hook. It is called with a stats source both for
+    data-pipeline transforms (during datamodule setup) and for model
+    postprocessors (via AtomisticModel.initialize_transforms). Do not store
+    the stats source, as this does not work with torchscript conversion!
     """
-
-    def datamodule(self, value):
-        """
-        Hook for transforms initialized from an AtomsDataModule.
-        Extract all required information from data module automatically when using
-        PyTorch Lightning integration. The transform should also implement a way to
-        set these things manually, to make it usable independent of PL.
-
-        Do not store the datamodule, as this does not work with torchscript conversion!
-        """
-        pass
 
     def forward(
         self,

--- a/src/schnetpack/transform/base.py
+++ b/src/schnetpack/transform/base.py
@@ -50,8 +50,12 @@ class Transform(nn.Module):
     def teardown(self):
         pass
 
-    def initialize(self, **kwargs) -> None:
+    def initialize(self, stats=None) -> None:
         """
-        Initialization hook for transforms that require training
+        Initialization hook for transforms that require training statistics.
+
+        Args:
+            stats: A stats source — any object providing ``get_stats`` and
+                ``get_atomrefs`` (e.g. the datamodule or its stats provider).
         """
         return

--- a/tests/data/conftest.py
+++ b/tests/data/conftest.py
@@ -26,9 +26,7 @@ def _build_stats_db(datapath, atomrefs=None):
         n_h = 1 + i % 4
         n_o = 1 + (i * 3) % 5
         numbers = [1] * n_h + [8] * n_o
-        atoms_list.append(
-            Atoms(numbers=numbers, positions=rng.randn(len(numbers), 3))
-        )
+        atoms_list.append(Atoms(numbers=numbers, positions=rng.randn(len(numbers), 3)))
         energy = -2.0 * n_h + 5.0 * n_o + 0.1 * (i % 7)
         property_list.append({ENERGY: np.array([energy])})
 

--- a/tests/data/conftest.py
+++ b/tests/data/conftest.py
@@ -1,0 +1,34 @@
+import os
+
+import numpy as np
+import pytest
+from ase import Atoms
+
+from schnetpack.data import ASEAtomsData
+
+ENERGY = "energy"
+
+
+@pytest.fixture
+def stats_dbpath(tmp_path):
+    """Small deterministic H/O dataset with known energies."""
+    datapath = os.path.join(tmp_path, "stats_test.db")
+    db = ASEAtomsData.create(
+        datapath, distance_unit="Ang", property_unit_dict={ENERGY: "eV"}
+    )
+
+    rng = np.random.RandomState(42)
+    atoms_list = []
+    property_list = []
+    for i in range(20):
+        n_h = 1 + i % 4
+        n_o = 1 + (i * 3) % 5
+        numbers = [1] * n_h + [8] * n_o
+        atoms_list.append(
+            Atoms(numbers=numbers, positions=rng.randn(len(numbers), 3))
+        )
+        energy = -2.0 * n_h + 5.0 * n_o + 0.1 * (i % 7)
+        property_list.append({ENERGY: np.array([energy])})
+
+    db.add_systems(property_list, atoms_list)
+    return datapath

--- a/tests/data/conftest.py
+++ b/tests/data/conftest.py
@@ -7,14 +7,16 @@ from ase import Atoms
 from schnetpack.data import ASEAtomsData
 
 ENERGY = "energy"
+H_ATOMREF = -2.5
+O_ATOMREF = 4.5
 
 
-@pytest.fixture
-def stats_dbpath(tmp_path):
-    """Small deterministic H/O dataset with known energies."""
-    datapath = os.path.join(tmp_path, "stats_test.db")
+def _build_stats_db(datapath, atomrefs=None):
     db = ASEAtomsData.create(
-        datapath, distance_unit="Ang", property_unit_dict={ENERGY: "eV"}
+        datapath,
+        distance_unit="Ang",
+        property_unit_dict={ENERGY: "eV"},
+        atomrefs=atomrefs,
     )
 
     rng = np.random.RandomState(42)
@@ -32,3 +34,21 @@ def stats_dbpath(tmp_path):
 
     db.add_systems(property_list, atoms_list)
     return datapath
+
+
+@pytest.fixture
+def stats_dbpath(tmp_path):
+    """Small deterministic H/O dataset with known energies, no atomrefs."""
+    return _build_stats_db(os.path.join(tmp_path, "stats_test.db"))
+
+
+@pytest.fixture
+def stats_dbpath_with_atomrefs(tmp_path):
+    """Same dataset, with single-atom references in the DB metadata."""
+    atomrefs = [0.0] * 100
+    atomrefs[1] = H_ATOMREF
+    atomrefs[8] = O_ATOMREF
+    return _build_stats_db(
+        os.path.join(tmp_path, "stats_test_atomrefs.db"),
+        atomrefs={ENERGY: atomrefs},
+    )

--- a/tests/data/test_datamodule_stats.py
+++ b/tests/data/test_datamodule_stats.py
@@ -74,9 +74,7 @@ def test_train_fingerprint_is_deterministic_across_create_and_load(
     assert dm_load.train_fingerprint == dm_create.train_fingerprint
 
 
-def test_train_fingerprint_changes_with_partition(
-    stats_dbpath, tmp_path, monkeypatch
-):
+def test_train_fingerprint_changes_with_partition(stats_dbpath, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     dm_a = _make_dm(stats_dbpath, tmp_path / "split_a.npz", num_train=10)
@@ -87,9 +85,7 @@ def test_train_fingerprint_changes_with_partition(
     assert dm_a.train_fingerprint != dm_b.train_fingerprint
 
 
-def test_second_datamodule_reads_stats_from_disk(
-    stats_dbpath, tmp_path, monkeypatch
-):
+def test_second_datamodule_reads_stats_from_disk(stats_dbpath, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     calls = _count_stats_calls(monkeypatch)
     split_file = tmp_path / "split.npz"
@@ -117,17 +113,13 @@ def test_stats_file_written_next_to_split_file(stats_dbpath, tmp_path, monkeypat
     assert os.path.exists(tmp_path / "split_stats.npz")
 
 
-def test_fingerprint_mismatch_triggers_recompute(
-    stats_dbpath, tmp_path, monkeypatch
-):
+def test_fingerprint_mismatch_triggers_recompute(stats_dbpath, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     calls = _count_stats_calls(monkeypatch)
     stats_file = str(tmp_path / "stats.npz")
     dataset = ASEAtomsData(stats_dbpath)
 
-    provider_a = StatsAtomrefProvider(
-        dataset, list(range(10)), stats_file=stats_file
-    )
+    provider_a = StatsAtomrefProvider(dataset, list(range(10)), stats_file=stats_file)
     provider_a.get_stats(ENERGY, True, False)
     assert len(calls) == 1
 
@@ -139,9 +131,7 @@ def test_fingerprint_mismatch_triggers_recompute(
     assert len(calls) == 1
 
     # different partition: stored entries are invalid, recompute
-    provider_b = StatsAtomrefProvider(
-        dataset, list(range(12)), stats_file=stats_file
-    )
+    provider_b = StatsAtomrefProvider(dataset, list(range(12)), stats_file=stats_file)
     provider_b.get_stats(ENERGY, True, False)
     assert len(calls) == 2
 

--- a/tests/data/test_datamodule_stats.py
+++ b/tests/data/test_datamodule_stats.py
@@ -5,11 +5,18 @@ fingerprint and the on-disk statistics cache derived from the split file.
 
 import os
 
+import torch
+
 import schnetpack.data.provider
-from schnetpack.data import ASEAtomsData, AtomsDataModule, calculate_stats
+from schnetpack.data import (
+    ASEAtomsData,
+    AtomsDataModule,
+    calculate_stats,
+    estimate_atomrefs,
+)
 from schnetpack.data.provider import StatsAtomrefProvider
 
-from .conftest import ENERGY
+from .conftest import ENERGY, H_ATOMREF
 
 
 def _make_dm(datapath, split_file, num_train=10, **kwargs):
@@ -33,6 +40,19 @@ def _count_stats_calls(monkeypatch):
 
     monkeypatch.setattr(
         schnetpack.data.provider, "calculate_stats", counting_calculate_stats
+    )
+    return calls
+
+
+def _count_atomref_calls(monkeypatch):
+    calls = []
+
+    def counting_estimate_atomrefs(*args, **kwargs):
+        calls.append(1)
+        return estimate_atomrefs(*args, **kwargs)
+
+    monkeypatch.setattr(
+        schnetpack.data.provider, "estimate_atomrefs", counting_estimate_atomrefs
     )
     return calls
 
@@ -141,3 +161,39 @@ def test_stats_file_none_disables_persistence(stats_dbpath, tmp_path, monkeypatc
     dm_second.setup()
     dm_second.get_stats(ENERGY, True, False)
     assert len(calls) == 2  # nothing persisted, so it recomputes
+
+
+def test_second_datamodule_reads_estimated_atomrefs_from_disk(
+    stats_dbpath, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    calls = _count_atomref_calls(monkeypatch)
+    split_file = tmp_path / "split.npz"
+
+    dm_first = _make_dm(stats_dbpath, split_file)
+    dm_first.setup()
+    first = dm_first.get_atomrefs(ENERGY, True)[ENERGY]
+    assert len(calls) == 1
+
+    dm_second = _make_dm(stats_dbpath, split_file)
+    dm_second.setup()
+    second = dm_second.get_atomrefs(ENERGY, True)[ENERGY]
+
+    assert len(calls) == 1  # read from disk, not re-estimated
+    assert torch.equal(second, first)
+
+
+def test_dataset_atomrefs_are_never_persisted(
+    stats_dbpath_with_atomrefs, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    calls = _count_atomref_calls(monkeypatch)
+
+    dm = _make_dm(stats_dbpath_with_atomrefs, tmp_path / "split.npz")
+    dm.setup()
+    refs = dm.get_atomrefs(ENERGY, True)[ENERGY]
+
+    assert refs[1] == H_ATOMREF
+    assert len(calls) == 0
+    # dataset-provided atomrefs live in the DB metadata; nothing to persist
+    assert not os.path.exists(tmp_path / "split_stats.npz")

--- a/tests/data/test_datamodule_stats.py
+++ b/tests/data/test_datamodule_stats.py
@@ -153,6 +153,26 @@ def test_stats_file_without_npz_extension_is_read_back(
     assert len(calls) == 1  # read from disk, not recomputed
 
 
+def test_regenerated_split_invalidates_persisted_stats(
+    stats_dbpath, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    calls = _count_stats_calls(monkeypatch)
+    split_file = tmp_path / "split.npz"
+
+    dm_first = _make_dm(stats_dbpath, split_file, num_train=10)
+    dm_first.setup()
+    dm_first.get_stats(ENERGY, True, False)
+    assert len(calls) == 1
+
+    # regenerate the split: same files, different train partition
+    os.remove(split_file)
+    dm_new = _make_dm(stats_dbpath, split_file, num_train=12)
+    dm_new.setup()
+    dm_new.get_stats(ENERGY, True, False)
+    assert len(calls) == 2  # stored stats belong to the old partition
+
+
 def test_corrupt_stats_file_is_ignored_and_rewritten(
     stats_dbpath, tmp_path, monkeypatch
 ):

--- a/tests/data/test_datamodule_stats.py
+++ b/tests/data/test_datamodule_stats.py
@@ -136,6 +136,28 @@ def test_fingerprint_mismatch_triggers_recompute(stats_dbpath, tmp_path, monkeyp
     assert len(calls) == 2
 
 
+def test_corrupt_stats_file_is_ignored_and_rewritten(
+    stats_dbpath, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    calls = _count_stats_calls(monkeypatch)
+    stats_file = tmp_path / "stats.npz"
+    stats_file.write_bytes(b"not an npz file")  # e.g. a crash mid-write
+
+    provider = StatsAtomrefProvider(
+        ASEAtomsData(stats_dbpath), list(range(10)), stats_file=str(stats_file)
+    )
+    provider.get_stats(ENERGY, True, False)
+    assert len(calls) == 1  # computed despite the unreadable file
+
+    # the file was rewritten: a second provider reads instead of recomputes
+    provider_second = StatsAtomrefProvider(
+        ASEAtomsData(stats_dbpath), list(range(10)), stats_file=str(stats_file)
+    )
+    provider_second.get_stats(ENERGY, True, False)
+    assert len(calls) == 1
+
+
 def test_stats_file_none_disables_persistence(stats_dbpath, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     calls = _count_stats_calls(monkeypatch)

--- a/tests/data/test_datamodule_stats.py
+++ b/tests/data/test_datamodule_stats.py
@@ -3,7 +3,13 @@ Tests for the datamodule's statistics plumbing: the train-partition
 fingerprint and the on-disk statistics cache derived from the split file.
 """
 
-from schnetpack.data import ASEAtomsData, AtomsDataModule
+import os
+
+import schnetpack.data.provider
+from schnetpack.data import ASEAtomsData, AtomsDataModule, calculate_stats
+from schnetpack.data.provider import StatsAtomrefProvider
+
+from .conftest import ENERGY
 
 
 def _make_dm(datapath, split_file, num_train=10, **kwargs):
@@ -16,6 +22,19 @@ def _make_dm(datapath, split_file, num_train=10, **kwargs):
         num_workers=0,
         **kwargs,
     )
+
+
+def _count_stats_calls(monkeypatch):
+    calls = []
+
+    def counting_calculate_stats(*args, **kwargs):
+        calls.append(1)
+        return calculate_stats(*args, **kwargs)
+
+    monkeypatch.setattr(
+        schnetpack.data.provider, "calculate_stats", counting_calculate_stats
+    )
+    return calls
 
 
 def test_train_fingerprint_is_deterministic_across_create_and_load(
@@ -46,3 +65,79 @@ def test_train_fingerprint_changes_with_partition(
     dm_b.setup()
 
     assert dm_a.train_fingerprint != dm_b.train_fingerprint
+
+
+def test_second_datamodule_reads_stats_from_disk(
+    stats_dbpath, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    calls = _count_stats_calls(monkeypatch)
+    split_file = tmp_path / "split.npz"
+
+    dm_first = _make_dm(stats_dbpath, split_file)
+    dm_first.setup()
+    first = dm_first.get_stats(ENERGY, True, False)
+    assert len(calls) == 1
+
+    dm_second = _make_dm(stats_dbpath, split_file)
+    dm_second.setup()
+    second = dm_second.get_stats(ENERGY, True, False)
+
+    assert len(calls) == 1  # read from disk, not recomputed
+    assert second[0] == first[0]
+    assert second[1] == first[1]
+
+
+def test_stats_file_written_next_to_split_file(stats_dbpath, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    dm = _make_dm(stats_dbpath, tmp_path / "split.npz")
+    dm.setup()
+    dm.get_stats(ENERGY, True, False)
+
+    assert os.path.exists(tmp_path / "split_stats.npz")
+
+
+def test_fingerprint_mismatch_triggers_recompute(
+    stats_dbpath, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    calls = _count_stats_calls(monkeypatch)
+    stats_file = str(tmp_path / "stats.npz")
+    dataset = ASEAtomsData(stats_dbpath)
+
+    provider_a = StatsAtomrefProvider(
+        dataset, list(range(10)), stats_file=stats_file
+    )
+    provider_a.get_stats(ENERGY, True, False)
+    assert len(calls) == 1
+
+    # same partition: served from disk
+    provider_same = StatsAtomrefProvider(
+        dataset, list(range(10)), stats_file=stats_file
+    )
+    provider_same.get_stats(ENERGY, True, False)
+    assert len(calls) == 1
+
+    # different partition: stored entries are invalid, recompute
+    provider_b = StatsAtomrefProvider(
+        dataset, list(range(12)), stats_file=stats_file
+    )
+    provider_b.get_stats(ENERGY, True, False)
+    assert len(calls) == 2
+
+
+def test_stats_file_none_disables_persistence(stats_dbpath, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    calls = _count_stats_calls(monkeypatch)
+    split_file = tmp_path / "split.npz"
+
+    dm_first = _make_dm(stats_dbpath, split_file, stats_file=None)
+    dm_first.setup()
+    dm_first.get_stats(ENERGY, True, False)
+
+    assert not os.path.exists(tmp_path / "split_stats.npz")
+
+    dm_second = _make_dm(stats_dbpath, split_file, stats_file=None)
+    dm_second.setup()
+    dm_second.get_stats(ENERGY, True, False)
+    assert len(calls) == 2  # nothing persisted, so it recomputes

--- a/tests/data/test_datamodule_stats.py
+++ b/tests/data/test_datamodule_stats.py
@@ -1,0 +1,48 @@
+"""
+Tests for the datamodule's statistics plumbing: the train-partition
+fingerprint and the on-disk statistics cache derived from the split file.
+"""
+
+from schnetpack.data import ASEAtomsData, AtomsDataModule
+
+
+def _make_dm(datapath, split_file, num_train=10, **kwargs):
+    return AtomsDataModule(
+        ASEAtomsData(datapath),
+        batch_size=5,
+        num_train=num_train,
+        num_val=5,
+        split_file=str(split_file),
+        num_workers=0,
+        **kwargs,
+    )
+
+
+def test_train_fingerprint_is_deterministic_across_create_and_load(
+    stats_dbpath, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    split_file = tmp_path / "split.npz"
+
+    dm_create = _make_dm(stats_dbpath, split_file)
+    dm_create.setup()
+
+    dm_load = _make_dm(stats_dbpath, split_file)
+    dm_load.setup()
+
+    assert isinstance(dm_create.train_fingerprint, str)
+    assert len(dm_create.train_fingerprint) > 0
+    assert dm_load.train_fingerprint == dm_create.train_fingerprint
+
+
+def test_train_fingerprint_changes_with_partition(
+    stats_dbpath, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    dm_a = _make_dm(stats_dbpath, tmp_path / "split_a.npz", num_train=10)
+    dm_a.setup()
+    dm_b = _make_dm(stats_dbpath, tmp_path / "split_b.npz", num_train=12)
+    dm_b.setup()
+
+    assert dm_a.train_fingerprint != dm_b.train_fingerprint

--- a/tests/data/test_datamodule_stats.py
+++ b/tests/data/test_datamodule_stats.py
@@ -136,6 +136,23 @@ def test_fingerprint_mismatch_triggers_recompute(stats_dbpath, tmp_path, monkeyp
     assert len(calls) == 2
 
 
+def test_stats_file_without_npz_extension_is_read_back(
+    stats_dbpath, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    calls = _count_stats_calls(monkeypatch)
+    stats_file = str(tmp_path / "mystats")  # np.savez appends ".npz"
+    dataset = ASEAtomsData(stats_dbpath)
+
+    provider_a = StatsAtomrefProvider(dataset, list(range(10)), stats_file=stats_file)
+    provider_a.get_stats(ENERGY, True, False)
+    assert len(calls) == 1
+
+    provider_b = StatsAtomrefProvider(dataset, list(range(10)), stats_file=stats_file)
+    provider_b.get_stats(ENERGY, True, False)
+    assert len(calls) == 1  # read from disk, not recomputed
+
+
 def test_corrupt_stats_file_is_ignored_and_rewritten(
     stats_dbpath, tmp_path, monkeypatch
 ):

--- a/tests/data/test_provider.py
+++ b/tests/data/test_provider.py
@@ -1,0 +1,56 @@
+"""
+Unit tests for StatsAtomrefProvider's pure interface: constructed from the
+base dataset plus an explicit train index list, it must serve raw-data
+statistics no matter what transforms are attached to the dataset.
+"""
+
+import torch
+
+import schnetpack.properties as structure
+from schnetpack.data import ASEAtomsData
+from schnetpack.data.provider import StatsAtomrefProvider
+from schnetpack.transform import RemoveOffsets
+
+from .conftest import ENERGY
+
+TRAIN_IDX = list(range(10))
+
+
+def _provider_on_transformed_base(datapath):
+    base = ASEAtomsData(
+        datapath,
+        transforms=[
+            RemoveOffsets(
+                ENERGY,
+                remove_mean=True,
+                is_extensive=True,
+                property_mean=torch.tensor([100.0]),
+            )
+        ],
+    )
+    return StatsAtomrefProvider(base, TRAIN_IDX)
+
+
+def test_provider_serves_raw_stats_for_train_indices(stats_dbpath):
+    provider = _provider_on_transformed_base(stats_dbpath)
+
+    mean, _std = provider.get_stats(ENERGY, True, False)
+
+    raw = ASEAtomsData(stats_dbpath)
+    per_atom = [raw[i][ENERGY] / raw[i][structure.n_atoms] for i in TRAIN_IDX]
+    expected = torch.cat(per_atom).mean()
+    assert torch.allclose(mean.double(), expected.double())
+
+
+def test_provider_estimates_atomrefs_on_raw_train_indices(stats_dbpath):
+    provider = _provider_on_transformed_base(stats_dbpath)
+
+    atomrefs = provider.get_atomrefs(ENERGY, True)[ENERGY]
+
+    from schnetpack.data import estimate_atomrefs
+
+    expected = estimate_atomrefs(
+        ASEAtomsData(stats_dbpath), is_extensive={ENERGY: True}, indices=TRAIN_IDX
+    )[ENERGY]
+    assert torch.count_nonzero(expected) > 0
+    assert torch.allclose(atomrefs, expected)

--- a/tests/data/test_provider.py
+++ b/tests/data/test_provider.py
@@ -58,9 +58,7 @@ def test_provider_estimates_atomrefs_on_raw_train_indices(stats_dbpath):
 
 
 def test_get_atomrefs_strict_returns_dataset_values(stats_dbpath_with_atomrefs):
-    provider = StatsAtomrefProvider(
-        ASEAtomsData(stats_dbpath_with_atomrefs), TRAIN_IDX
-    )
+    provider = StatsAtomrefProvider(ASEAtomsData(stats_dbpath_with_atomrefs), TRAIN_IDX)
 
     refs = provider.get_atomrefs(ENERGY, True, estimate=False)[ENERGY]
 

--- a/tests/data/test_provider.py
+++ b/tests/data/test_provider.py
@@ -4,6 +4,7 @@ base dataset plus an explicit train index list, it must serve raw-data
 statistics no matter what transforms are attached to the dataset.
 """
 
+import pytest
 import torch
 
 import schnetpack.properties as structure
@@ -11,7 +12,7 @@ from schnetpack.data import ASEAtomsData
 from schnetpack.data.provider import StatsAtomrefProvider
 from schnetpack.transform import RemoveOffsets
 
-from .conftest import ENERGY
+from .conftest import ENERGY, H_ATOMREF, O_ATOMREF
 
 TRAIN_IDX = list(range(10))
 
@@ -54,3 +55,42 @@ def test_provider_estimates_atomrefs_on_raw_train_indices(stats_dbpath):
     )[ENERGY]
     assert torch.count_nonzero(expected) > 0
     assert torch.allclose(atomrefs, expected)
+
+
+def test_get_atomrefs_strict_returns_dataset_values(stats_dbpath_with_atomrefs):
+    provider = StatsAtomrefProvider(
+        ASEAtomsData(stats_dbpath_with_atomrefs), TRAIN_IDX
+    )
+
+    refs = provider.get_atomrefs(ENERGY, True, estimate=False)[ENERGY]
+
+    assert refs[1] == pytest.approx(H_ATOMREF)
+    assert refs[8] == pytest.approx(O_ATOMREF)
+
+
+def test_get_atomrefs_strict_raises_without_dataset_values(stats_dbpath):
+    provider = StatsAtomrefProvider(ASEAtomsData(stats_dbpath), TRAIN_IDX)
+
+    with pytest.raises(RuntimeError, match=ENERGY):
+        provider.get_atomrefs(ENERGY, True, estimate=False)
+
+
+def test_datamodule_get_atomrefs_passes_estimate_through(
+    stats_dbpath, tmp_path, monkeypatch
+):
+    from schnetpack.data import AtomsDataModule
+
+    monkeypatch.chdir(tmp_path)
+    dm = AtomsDataModule(
+        ASEAtomsData(stats_dbpath),
+        batch_size=5,
+        num_train=10,
+        num_val=5,
+        num_test=5,
+        split_file=str(tmp_path / "split.npz"),
+        num_workers=0,
+    )
+    dm.setup()
+
+    with pytest.raises(RuntimeError, match=ENERGY):
+        dm.get_atomrefs(ENERGY, True, estimate=False)

--- a/tests/data/test_stats.py
+++ b/tests/data/test_stats.py
@@ -1,0 +1,70 @@
+"""
+Unit tests for the explicit-indices interface of the statistics functions.
+
+`calculate_stats` and `estimate_atomrefs` accept the dataset plus an explicit
+index list and must compute on the raw data — regardless of any transforms or
+split label attached to the dataset they are handed.
+"""
+
+import torch
+
+import schnetpack.properties as structure
+from schnetpack.data import ASEAtomsData, calculate_stats, estimate_atomrefs
+from schnetpack.transform import RemoveOffsets
+
+from .conftest import ENERGY
+
+
+def _shift_transform(offset):
+    """A self-contained transform that shifts the energy on every access."""
+    return RemoveOffsets(
+        ENERGY,
+        remove_mean=True,
+        is_extensive=True,
+        property_mean=torch.tensor([offset]),
+    )
+
+
+def _transformed_view(datapath):
+    """A dataset view with both plain and split-specific transforms attached."""
+    base = ASEAtomsData(
+        datapath,
+        transforms=[_shift_transform(100.0)],
+        train_transforms=[_shift_transform(200.0)],
+    )
+    return base.subset(list(range(len(base))), split="train")
+
+
+def _manual_per_atom_mean(datapath, indices):
+    raw = ASEAtomsData(datapath)
+    per_atom = [raw[i][ENERGY] / raw[i][structure.n_atoms] for i in indices]
+    return torch.cat(per_atom).mean()
+
+
+def test_calculate_stats_with_indices_yields_raw_statistics(stats_dbpath):
+    view = _transformed_view(stats_dbpath)
+    indices = list(range(10))
+
+    mean, _std = calculate_stats(
+        view, divide_by_atoms={ENERGY: True}, indices=indices
+    )[ENERGY]
+
+    expected = _manual_per_atom_mean(stats_dbpath, indices)
+    expected_all = _manual_per_atom_mean(stats_dbpath, range(len(view)))
+    assert not torch.allclose(expected, expected_all)  # indices must matter
+    assert torch.allclose(mean.double(), expected.double())
+
+
+def test_estimate_atomrefs_with_indices_yields_raw_estimates(stats_dbpath):
+    view = _transformed_view(stats_dbpath)
+    indices = list(range(10))
+
+    atomrefs = estimate_atomrefs(view, is_extensive={ENERGY: True}, indices=indices)[
+        ENERGY
+    ]
+
+    raw_subset = ASEAtomsData(stats_dbpath).subset(indices)
+    expected = estimate_atomrefs(raw_subset, is_extensive={ENERGY: True})[ENERGY]
+
+    assert torch.count_nonzero(expected) > 0
+    assert torch.allclose(atomrefs, expected)

--- a/tests/data/test_stats.py
+++ b/tests/data/test_stats.py
@@ -45,9 +45,9 @@ def test_calculate_stats_with_indices_yields_raw_statistics(stats_dbpath):
     view = _transformed_view(stats_dbpath)
     indices = list(range(10))
 
-    mean, _std = calculate_stats(
-        view, divide_by_atoms={ENERGY: True}, indices=indices
-    )[ENERGY]
+    mean, _std = calculate_stats(view, divide_by_atoms={ENERGY: True}, indices=indices)[
+        ENERGY
+    ]
 
     expected = _manual_per_atom_mean(stats_dbpath, indices)
     expected_all = _manual_per_atom_mean(stats_dbpath, range(len(view)))

--- a/tests/data/test_stats_e2e.py
+++ b/tests/data/test_stats_e2e.py
@@ -11,42 +11,14 @@ prediction by a constant.
 
 import os
 
-import numpy as np
-import pytest
 import torch
-from ase import Atoms
 
 import schnetpack.properties as structure
 from schnetpack.data import ASEAtomsData, AtomsDataModule, estimate_atomrefs
 from schnetpack.model import AtomisticModel
 from schnetpack.transform import AddOffsets, RemoveOffsets
 
-ENERGY = "energy"
-
-
-@pytest.fixture
-def stats_dbpath(tmp_path):
-    """Small deterministic H/O dataset with known energies."""
-    datapath = os.path.join(tmp_path, "stats_test.db")
-    db = ASEAtomsData.create(
-        datapath, distance_unit="Ang", property_unit_dict={ENERGY: "eV"}
-    )
-
-    rng = np.random.RandomState(42)
-    atoms_list = []
-    property_list = []
-    for i in range(20):
-        n_h = 1 + i % 4
-        n_o = 1 + (i * 3) % 5
-        numbers = [1] * n_h + [8] * n_o
-        atoms_list.append(
-            Atoms(numbers=numbers, positions=rng.randn(len(numbers), 3))
-        )
-        energy = -2.0 * n_h + 5.0 * n_o + 0.1 * (i % 7)
-        property_list.append({ENERGY: np.array([energy])})
-
-    db.add_systems(property_list, atoms_list)
-    return datapath
+from .conftest import ENERGY
 
 
 def _setup_datamodule(datapath, tmp_path, transforms):

--- a/tests/data/test_stats_e2e.py
+++ b/tests/data/test_stats_e2e.py
@@ -1,0 +1,149 @@
+"""
+End-to-end regression tests for training statistics (review finding S1).
+
+The data-pipeline offset transform (RemoveOffsets) and the model
+postprocessor (AddOffsets) must hold the identical raw-training-data
+statistics, even when the postprocessor is initialized late — after the
+train dataset already has its transforms attached. Historically the late
+path recomputed statistics on already-transformed data, shifting every
+prediction by a constant.
+"""
+
+import os
+
+import numpy as np
+import pytest
+import torch
+from ase import Atoms
+
+import schnetpack.properties as structure
+from schnetpack.data import ASEAtomsData, AtomsDataModule, estimate_atomrefs
+from schnetpack.model import AtomisticModel
+from schnetpack.transform import AddOffsets, RemoveOffsets
+
+ENERGY = "energy"
+
+
+@pytest.fixture
+def stats_dbpath(tmp_path):
+    """Small deterministic H/O dataset with known energies."""
+    datapath = os.path.join(tmp_path, "stats_test.db")
+    db = ASEAtomsData.create(
+        datapath, distance_unit="Ang", property_unit_dict={ENERGY: "eV"}
+    )
+
+    rng = np.random.RandomState(42)
+    atoms_list = []
+    property_list = []
+    for i in range(20):
+        n_h = 1 + i % 4
+        n_o = 1 + (i * 3) % 5
+        numbers = [1] * n_h + [8] * n_o
+        atoms_list.append(
+            Atoms(numbers=numbers, positions=rng.randn(len(numbers), 3))
+        )
+        energy = -2.0 * n_h + 5.0 * n_o + 0.1 * (i % 7)
+        property_list.append({ENERGY: np.array([energy])})
+
+    db.add_systems(property_list, atoms_list)
+    return datapath
+
+
+def _setup_datamodule(datapath, tmp_path, transforms):
+    dataset = ASEAtomsData(datapath, transforms=transforms)
+    dm = AtomsDataModule(
+        dataset,
+        batch_size=5,
+        num_train=10,
+        num_val=5,
+        num_test=5,
+        split_file=os.path.join(tmp_path, "split.npz"),
+        num_workers=0,
+    )
+    dm.setup()
+    return dm
+
+
+def _raw_train_subset(datapath, train_idx):
+    """Independent raw view: fresh dataset instance, no transforms, no split."""
+    return ASEAtomsData(datapath).subset(list(train_idx))
+
+
+def _raw_per_atom_mean(datapath, train_idx):
+    subset = _raw_train_subset(datapath, train_idx)
+    per_atom = [
+        subset[i][ENERGY] / subset[i][structure.n_atoms] for i in range(len(subset))
+    ]
+    return torch.cat(per_atom).mean()
+
+
+def _late_initialized_postprocessor(dm, **offset_kwargs):
+    """Initialize AddOffsets through the model path, after dm.setup()."""
+    model = AtomisticModel(
+        postprocessors=[AddOffsets(ENERGY, is_extensive=True, **offset_kwargs)]
+    )
+    model.initialize_transforms(dm)
+    return model.postprocessors[0]
+
+
+def test_offset_mean_consistent_with_late_postprocessor(
+    stats_dbpath, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    remove_offsets = RemoveOffsets(ENERGY, remove_mean=True, is_extensive=True)
+    dm = _setup_datamodule(stats_dbpath, tmp_path, [remove_offsets])
+
+    # postprocessor initialized late: train transforms are already attached
+    add_offsets = _late_initialized_postprocessor(dm, add_mean=True)
+
+    expected_mean = _raw_per_atom_mean(stats_dbpath, dm.train_idx)
+
+    assert torch.allclose(remove_offsets.mean.double(), expected_mean.double())
+    assert torch.allclose(add_offsets.mean.double(), expected_mean.double())
+    assert torch.allclose(add_offsets.mean, remove_offsets.mean)
+
+
+def test_pipeline_actually_removes_raw_mean(stats_dbpath, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    remove_offsets = RemoveOffsets(ENERGY, remove_mean=True, is_extensive=True)
+    dm = _setup_datamodule(stats_dbpath, tmp_path, [remove_offsets])
+
+    raw_subset = _raw_train_subset(stats_dbpath, dm.train_idx)
+    expected_mean = _raw_per_atom_mean(stats_dbpath, dm.train_idx)
+
+    transformed = dm.train_dataset[0]
+    raw = raw_subset[0]
+    assert torch.allclose(
+        transformed[ENERGY].double(),
+        (raw[ENERGY] - expected_mean * raw[structure.n_atoms]).double(),
+    )
+
+
+def test_estimated_atomrefs_consistent_with_late_postprocessor(
+    stats_dbpath, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    remove_offsets = RemoveOffsets(
+        ENERGY,
+        remove_mean=True,
+        remove_atomrefs=True,
+        estimate_atomref=True,
+        is_extensive=True,
+    )
+    dm = _setup_datamodule(stats_dbpath, tmp_path, [remove_offsets])
+
+    add_offsets = _late_initialized_postprocessor(
+        dm, add_mean=True, add_atomrefs=True, estimate_atomref=True
+    )
+
+    expected_atomrefs = estimate_atomrefs(
+        _raw_train_subset(stats_dbpath, dm.train_idx), is_extensive={ENERGY: True}
+    )[ENERGY]
+
+    assert torch.count_nonzero(expected_atomrefs) > 0
+    assert torch.allclose(remove_offsets.atomref, expected_atomrefs)
+    assert torch.allclose(add_offsets.atomref, expected_atomrefs)
+    assert torch.allclose(add_offsets.mean, remove_offsets.mean)

--- a/tests/data/test_transform_init.py
+++ b/tests/data/test_transform_init.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for the unified transform initialization: `initialize(stats)`
+takes a single stats source — any object with `get_stats`/`get_atomrefs`,
+i.e. the datamodule's provider or the datamodule itself.
+"""
+
+import pytest
+import torch
+
+import schnetpack.properties as structure
+from schnetpack.data import ASEAtomsData, AtomsDataModule
+from schnetpack.data.provider import StatsAtomrefProvider
+from schnetpack.transform import AddOffsets, RemoveOffsets, ScaleProperty
+
+from .conftest import ENERGY, H_ATOMREF, O_ATOMREF
+
+TRAIN_IDX = list(range(10))
+
+
+def test_remove_offsets_reads_dataset_atomrefs_from_stats_source(
+    stats_dbpath_with_atomrefs,
+):
+    provider = StatsAtomrefProvider(
+        ASEAtomsData(stats_dbpath_with_atomrefs), TRAIN_IDX
+    )
+    transform = RemoveOffsets(
+        ENERGY, remove_atomrefs=True, estimate_atomref=False, is_extensive=True
+    )
+
+    transform.initialize(provider)
+
+    assert transform.atomref[1] == pytest.approx(H_ATOMREF)
+    assert transform.atomref[8] == pytest.approx(O_ATOMREF)
+
+
+def test_add_offsets_reads_dataset_atomrefs_from_stats_source(
+    stats_dbpath_with_atomrefs,
+):
+    provider = StatsAtomrefProvider(
+        ASEAtomsData(stats_dbpath_with_atomrefs), TRAIN_IDX
+    )
+    transform = AddOffsets(
+        ENERGY, add_atomrefs=True, estimate_atomref=False, is_extensive=True
+    )
+
+    transform.initialize(provider)
+
+    assert transform.atomref[1] == pytest.approx(H_ATOMREF)
+    assert transform.atomref[8] == pytest.approx(O_ATOMREF)
+
+
+def test_strict_atomref_initialization_fails_without_dataset_atomrefs(
+    stats_dbpath,
+):
+    provider = StatsAtomrefProvider(ASEAtomsData(stats_dbpath), TRAIN_IDX)
+    transform = RemoveOffsets(
+        ENERGY, remove_atomrefs=True, estimate_atomref=False, is_extensive=True
+    )
+
+    with pytest.raises(RuntimeError, match=ENERGY):
+        transform.initialize(provider)
+
+
+def test_scale_property_initializes_from_stats_source(stats_dbpath):
+    dataset = ASEAtomsData(stats_dbpath)
+    provider = StatsAtomrefProvider(dataset, TRAIN_IDX)
+    transform = ScaleProperty(input_key=ENERGY)
+
+    transform.initialize(provider)
+
+    per_atom = [
+        dataset[i][ENERGY] / dataset[i][structure.n_atoms] for i in TRAIN_IDX
+    ]
+    expected_std = torch.cat(per_atom).double().std(correction=0)
+    assert torch.allclose(transform.scale.double(), expected_std)
+
+
+def test_datamodule_satisfies_the_stats_source_protocol(
+    stats_dbpath_with_atomrefs, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    dm = AtomsDataModule(
+        ASEAtomsData(stats_dbpath_with_atomrefs),
+        batch_size=5,
+        num_train=10,
+        num_val=5,
+        num_test=5,
+        split_file=str(tmp_path / "split.npz"),
+        num_workers=0,
+    )
+    dm.setup()
+
+    transform = AddOffsets(
+        ENERGY,
+        add_mean=True,
+        add_atomrefs=True,
+        estimate_atomref=False,
+        is_extensive=True,
+    )
+    transform.initialize(dm)
+
+    assert transform.atomref[1] == pytest.approx(H_ATOMREF)
+    mean, _std = dm.get_stats(ENERGY, True, True)
+    assert torch.allclose(transform.mean, mean)

--- a/tests/data/test_transform_init.py
+++ b/tests/data/test_transform_init.py
@@ -20,9 +20,7 @@ TRAIN_IDX = list(range(10))
 def test_remove_offsets_reads_dataset_atomrefs_from_stats_source(
     stats_dbpath_with_atomrefs,
 ):
-    provider = StatsAtomrefProvider(
-        ASEAtomsData(stats_dbpath_with_atomrefs), TRAIN_IDX
-    )
+    provider = StatsAtomrefProvider(ASEAtomsData(stats_dbpath_with_atomrefs), TRAIN_IDX)
     transform = RemoveOffsets(
         ENERGY, remove_atomrefs=True, estimate_atomref=False, is_extensive=True
     )
@@ -36,9 +34,7 @@ def test_remove_offsets_reads_dataset_atomrefs_from_stats_source(
 def test_add_offsets_reads_dataset_atomrefs_from_stats_source(
     stats_dbpath_with_atomrefs,
 ):
-    provider = StatsAtomrefProvider(
-        ASEAtomsData(stats_dbpath_with_atomrefs), TRAIN_IDX
-    )
+    provider = StatsAtomrefProvider(ASEAtomsData(stats_dbpath_with_atomrefs), TRAIN_IDX)
     transform = AddOffsets(
         ENERGY, add_atomrefs=True, estimate_atomref=False, is_extensive=True
     )
@@ -68,9 +64,7 @@ def test_scale_property_initializes_from_stats_source(stats_dbpath):
 
     transform.initialize(provider)
 
-    per_atom = [
-        dataset[i][ENERGY] / dataset[i][structure.n_atoms] for i in TRAIN_IDX
-    ]
+    per_atom = [dataset[i][ENERGY] / dataset[i][structure.n_atoms] for i in TRAIN_IDX]
     expected_std = torch.cat(per_atom).double().std(correction=0)
     assert torch.allclose(transform.scale.double(), expected_std)
 


### PR DESCRIPTION
Follow-up to the dataset refactor (#781), executing the statistics refactor plan (REVIEW_FIXES.md items S1/D3). Statistics become a pure function of (base dataset, train indices) with a single owner and one query interface, and are persisted next to the split file.

## What changed

1. **Pure-function statistics** — `calculate_stats` / `estimate_atomrefs` take an optional `indices` parameter and build their own raw (transform-free, split-free) view internally. "Statistics are computed on raw data" is now the functions' contract, enforced in one place; the shallow-copy trick in the provider is deleted.
2. **One initialization path** — transforms are initialized through a single `initialize(stats)` taking any object with `get_stats`/`get_atomrefs` (the provider or the datamodule). The `Transform.datamodule()` hook is **hard-deleted**; `AtomisticModel.initialize_transforms` passes the datamodule as the stats source. The strict no-estimation atomref case is an explicit `estimate=False` mode of the atomref query, replacing the side-channel `atomrefs=` argument.
3. **Disk cache next to the split file** — computed stats and estimated atomrefs are persisted to `<split>_stats.npz`, keyed by a fingerprint of the train partition, read-modify-written while holding the same inter-process lock as split creation (held across miss→compute→write, so concurrent DDP ranks compute each entry at most once). On by default; `stats_file=None` opts out. Dataset-provided atomrefs are never persisted. Unreadable cache files fall back to recompute-and-overwrite.

The cornerstone test (commit 1) ports the review's end-to-end S1 check into the suite: `RemoveOffsets` and a late-initialized `AddOffsets` postprocessor must hold the identical, independently recomputed raw training mean. It passes on the base branch and on every commit of this PR.

## Commits

Ten planned commits (tests-first, each leaving the suite green — verified by running the full suite at every commit), plus black formatting, two hardening fixes from a pre-PR review pass (lock held across compute; corrupt-cache tolerance), and two commits from a post-implementation audit: a stats-file extension fix (a user-supplied `stats_file` without `.npz` was written by `np.savez` under the appended extension but read back at the verbatim path, so the cache silently never hit) and a literal regenerated-split invalidation test.

## Known limitations (deliberate)

- The splitting/stats lock file remains cwd-relative (inherited from the existing split lock); processes with different working directories sharing one stats file take different locks.
- The fingerprint covers (dataset length, train partition) — regenerating the database in place with identical length would not invalidate persisted stats, same as it would not invalidate `split.npz`. Delete the stats file or set `stats_file=None` in that case.
- Persisted stats entries are scalar per (property, flags) — matching `calculate_stats`, which reduces each property to scalar mean/std.

## Test plan

- `pytest tests/`: 86 passed, 3 skipped (base branch: 60 passed, 3 skipped); suite verified green at each individual commit.
- `black --check .` clean with the pinned black==24.4.2.
- New tests: e2e offset consistency incl. late postprocessor init (S1 regression), raw-view guarantee of the stats functions, provider pure interface, strict atomref mode, fingerprint determinism/invalidation, disk cache read-instead-of-recompute, split-regeneration invalidation, opt-out, never-persist dataset atomrefs, corrupt-cache recovery, non-`.npz` stats-file round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
