### PR TITLE
hydra search path bug

### DIFF
--- a/src/schnetpack/configs/train.yaml
+++ b/src/schnetpack/configs/train.yaml
@@ -31,8 +31,8 @@ hydra:
         dir: ${run.path}/${run.id}
 
     searchpath:
-      - file://${oc.env:PWD}
-      - file://${oc.env:PWD}/configs
+      - file://.
+      - file://./configs
 
     # disable hydra config storage, since handled manually
     output_subdir: null


### PR DESCRIPTION
Replace `${oc.env:PWD}` with relative paths in the Hydra config search path. This fixes configuration resolution with newer Hydra/OmegaConf versions.
