### PR TITLE
Keep <torch/torch.h> out of pair_schnetpack.h

### DIFF
--- a/interfaces/lammps/pair_schnetpack.cpp
+++ b/interfaces/lammps/pair_schnetpack.cpp
@@ -33,17 +33,26 @@ References:
 
 using namespace LAMMPS_NS;
 
-PairSCHNETPACK::PairSCHNETPACK(LAMMPS *lmp) : Pair(lmp) {
+// Defined here, in the only translation unit that includes libtorch, so that
+// torch's headers are never visible to the rest of LAMMPS via style_pair.h.
+namespace LAMMPS_NS {
+struct PairSCHNETPACK::Impl {
+  torch::jit::script::Module model;
+  torch::Device device = torch::kCPU;
+};
+}
+
+PairSCHNETPACK::PairSCHNETPACK(LAMMPS *lmp) : Pair(lmp), impl(new Impl) {
   restartinfo = 0;
   manybody_flag = 1;
 
   if(torch::cuda::is_available()){
-    device = torch::kCUDA;
+    impl->device = torch::kCUDA;
   }
   else {
-    device = torch::kCPU;
+    impl->device = torch::kCPU;
   }
-  std::cout << "SCHNETPACK is using device " << device << "\n";
+  std::cout << "SCHNETPACK is using device " << impl->device << "\n";
 
   if(const char* env_p = std::getenv("SCHNETPACK_DEBUG")){
     std::cout << "PairSCHNETPACK is in DEBUG mode, since SCHNETPACK_DEBUG is in env\n";
@@ -125,8 +134,8 @@ void PairSCHNETPACK::coeff(int narg, char **arg) {
   std::unordered_map<std::string, std::string> metadata = {
     {"cutoff", ""},
   };
-  model = torch::jit::load(std::string(arg[2]), device, metadata);
-  model.eval();
+  impl->model = torch::jit::load(std::string(arg[2]), impl->device, metadata);
+  impl->model.eval();
 
 
   cutoff = std::stod(metadata["cutoff"]);
@@ -304,14 +313,14 @@ void PairSCHNETPACK::compute(int eflag, int vflag){
 
 
   c10::Dict<std::string, torch::Tensor> input;
-  input.insert("_positions", positions_tensor.to(device));
-  input.insert("_idx_i", idx_i_tensor.to(device));
-  input.insert("_idx_j", idx_j_tensor.to(device));
-  input.insert("_idx_m", idx_m_tensor.to(device));
-  input.insert("_offsets", offsets_tensor.to(device));
-  input.insert("_cell", cell_tensor.to(device));
-  input.insert("_n_atoms", n_atoms_tensor.to(device));
-  input.insert("_atomic_numbers", atomic_numbers_tensor.to(device));
+  input.insert("_positions", positions_tensor.to(impl->device));
+  input.insert("_idx_i", idx_i_tensor.to(impl->device));
+  input.insert("_idx_j", idx_j_tensor.to(impl->device));
+  input.insert("_idx_m", idx_m_tensor.to(impl->device));
+  input.insert("_offsets", offsets_tensor.to(impl->device));
+  input.insert("_cell", cell_tensor.to(impl->device));
+  input.insert("_n_atoms", n_atoms_tensor.to(impl->device));
+  input.insert("_atomic_numbers", atomic_numbers_tensor.to(impl->device));
   std::vector<torch::IValue> input_vector(1, input);
 
   if(debug_mode){
@@ -325,7 +334,7 @@ void PairSCHNETPACK::compute(int eflag, int vflag){
     std::cout << "_atomic_numbers:\n" << atomic_numbers_tensor << "\n";
   }
   
-  auto output = model.forward(input_vector).toGenericDict();
+  auto output = impl->model.forward(input_vector).toGenericDict();
   
   torch::Tensor forces_tensor = output.at("forces").toTensor().cpu();
   auto forces = forces_tensor.accessor<float, 2>();

--- a/interfaces/lammps/pair_schnetpack.h
+++ b/interfaces/lammps/pair_schnetpack.h
@@ -17,7 +17,7 @@ PairStyle(schnetpack,PairSCHNETPACK)
 
 #include "pair.h"
 
-#include <torch/torch.h>
+#include <memory>
 
 namespace LAMMPS_NS {
     
@@ -33,8 +33,15 @@ class PairSCHNETPACK : public Pair {
   void allocate();
 
   double cutoff;
-  torch::jit::script::Module model;
-  torch::Device device = torch::kCPU;
+
+  // The libtorch state is held behind an opaque pointer so that this header
+  // does not include <torch/torch.h>. LAMMPS pulls every pair-style header
+  // into the generated style_pair.h, which force.cpp and lammps.cpp include
+  // after their own "using namespace LAMMPS_NS;" -- and there the unqualified
+  // "Device" that ATen uses matches both c10::Device and the LAMMPS_NS::Device
+  // enumerator of "enum ExecutionSpace" in src/pointers.h.
+  struct Impl;
+  std::unique_ptr<Impl> impl;
 
  protected:
   int * type_mapper;


### PR DESCRIPTION
## Problem

Building LAMMPS with the SchNetPack pair style fails during compilation of
`force.cpp` and `lammps.cpp`:

```
ATen/core/Generator.h:121:3: error: reference to 'Device' is ambiguous
  note: candidates are: 'LAMMPS_NS::ExecutionSpace LAMMPS_NS::Device'
  note:                 'struct c10::Device'
ATen/core/Generator.h:155:3: error: 'struct at::Generator' has no member named 'device'
ATen/core/TensorBase.h:587:41: error: too few arguments to function 'c10::TensorOptions c10::device(Device)'
```

...and several hundred more, all downstream of that first ambiguity.

## Cause

`pair_schnetpack.h` includes `<torch/torch.h>` at file scope. LAMMPS collects
every pair-style header into the generated `style_pair.h`, which `force.cpp`
and `lammps.cpp` include **after** their own `using namespace LAMMPS_NS;`.

libtorch's headers are therefore parsed with `LAMMPS_NS` injected into the
global scope, so the unqualified `Device` that ATen uses matches two
candidates:

| | |
|---|---|
| `c10::Device` | `c10/core/Device.h` — visible via `using namespace c10;` inside `namespace at` |
| `LAMMPS_NS::Device` | an enumerator of `enum ExecutionSpace { Host, Device }` in LAMMPS `src/pointers.h` |

Both resolve at global scope, so the lookup is ambiguous.

Note that only `force.cpp` and `lammps.cpp` fail. `pair_schnetpack.cpp` itself
compiles fine, because it includes its own header *before* the using-directive.
The bug is purely one of include order, which is why it does not show up when
building the pair style in isolation.

Also worth recording: the `ExecutionSpace` enum is **not** guarded by
`#ifdef LMP_KOKKOS` despite the comment above it, so disabling KOKKOS does not
avoid the clash.

## Fix

Hold the TorchScript module and its device behind an opaque pointer, defined in
`pair_schnetpack.cpp` — the only translation unit that includes libtorch. The
header then needs only `<memory>`.

```cpp
// pair_schnetpack.h
struct Impl;
std::unique_ptr<Impl> impl;

// pair_schnetpack.cpp
namespace LAMMPS_NS {
struct PairSCHNETPACK::Impl {
  torch::jit::script::Module model;
  torch::Device device = torch::kCPU;
};
}
```

The destructor is already defined out-of-line in the `.cpp`, which is what
`std::unique_ptr` to an incomplete type requires, so no change was needed there.

## What does not change

The pair style still requires and links libtorch. Only header *visibility*
moves — the same model is loaded onto the same device and run the same way.
Input script syntax, model files and results are unaffected. The overhead is
one pointer dereference per access, against a neural-network forward pass.

## Tested with

LAMMPS 22Jul2025_update5 (KOKKOS, OpenMP, MPI), PyTorch 2.13.0, GCC 15.2.0,
CUDA 13.2.1, C++17. Builds cleanly with the patch; fails without it.

## Related

The same collision affects other libtorch-based LAMMPS pair styles —
mir-group/pair_nequip_allegro#66 reports identical errors on GCC 11.4.1 /
PyTorch 2.6, and is still open. This suggests it started surfacing with newer
PyTorch headers rather than being compiler-specific.